### PR TITLE
Buttons graying out bugfix

### DIFF
--- a/button_commands/actionconfirm.js
+++ b/button_commands/actionconfirm.js
@@ -1,6 +1,6 @@
 const {
-  ButtonBuilder,
-  ActionRowBuilder,
+  // ButtonBuilder,
+  // ActionRowBuilder,
   EmbedBuilder,
   PermissionsBitField,
   MessageFlags,
@@ -29,33 +29,33 @@ module.exports = async ({ interaction, client, userid, context }) => {
     throw new Error("Could not fetch user ID from the embed");
   }
 
-  const disverify = new ActionRowBuilder().addComponents(
-    new ButtonBuilder()
-      .setCustomId("verify")
-      .setLabel("Verify")
-      .setStyle("Success")
-      .setDisabled(true),
-    new ButtonBuilder()
-      .setCustomId("deny")
-      .setLabel("Deny")
-      .setStyle("Danger")
-      .setDisabled(true),
-    new ButtonBuilder()
-      .setCustomId("reasondeny")
-      .setLabel("Deny with reason")
-      .setStyle("Danger")
-      .setDisabled(true),
-    new ButtonBuilder()
-      .setCustomId("question")
-      .setLabel("Question")
-      .setStyle("Primary")
-      .setDisabled(true),
-    new ButtonBuilder()
-      .setCustomId("action")
-      .setLabel("Kick")
-      .setStyle("Secondary")
-      .setDisabled(true),
-  );
+  // const disverify = new ActionRowBuilder().addComponents(
+  //   new ButtonBuilder()
+  //     .setCustomId("verify")
+  //     .setLabel("Verify")
+  //     .setStyle("Success")
+  //     .setDisabled(true),
+  //   new ButtonBuilder()
+  //     .setCustomId("deny")
+  //     .setLabel("Deny")
+  //     .setStyle("Danger")
+  //     .setDisabled(true),
+  //   new ButtonBuilder()
+  //     .setCustomId("reasondeny")
+  //     .setLabel("Deny with reason")
+  //     .setStyle("Danger")
+  //     .setDisabled(true),
+  //   new ButtonBuilder()
+  //     .setCustomId("question")
+  //     .setLabel("Question")
+  //     .setStyle("Primary")
+  //     .setDisabled(true),
+  //   new ButtonBuilder()
+  //     .setCustomId("action")
+  //     .setLabel("Kick")
+  //     .setStyle("Secondary")
+  //     .setDisabled(true),
+  // );
 
   const serverConfig = await ServerConfig.findOne({
     where: { server_id: interaction.guild.id },
@@ -143,12 +143,12 @@ module.exports = async ({ interaction, client, userid, context }) => {
   });
   const messageids = verification?.guildVerifications?.[interaction.guild.id];
 
-  if (interaction.message.flags.has(MessageFlags.IsComponentsV2)) {
-    const originalContainer = interaction.message.components[0];
-    interaction.editReply({ components: [originalContainer, disverify] });
-  } else {
-    await interaction.editReply({ components: [disverify] });
-  }
+  // if (interaction.message.flags.has(MessageFlags.IsComponentsV2)) {
+  //   const originalContainer = interaction.message.components[0];
+  //   interaction.editReply({ components: [originalContainer, disverify] });
+  // } else {
+  //   await interaction.editReply({ components: [disverify] });
+  // }
 
   if (
     serverConfig.verifylogs &&

--- a/button_commands/denyconfirm.js
+++ b/button_commands/denyconfirm.js
@@ -1,6 +1,6 @@
 const {
-  ButtonBuilder,
-  ActionRowBuilder,
+  // ButtonBuilder,
+  // ActionRowBuilder,
   EmbedBuilder,
   MessageFlags,
   ContainerBuilder,
@@ -28,33 +28,33 @@ module.exports = async ({ interaction, client, userid, context }) => {
     throw new Error("Could not fetch user ID from the embed");
   }
 
-  const disverify = new ActionRowBuilder().addComponents(
-    new ButtonBuilder()
-      .setCustomId("verify")
-      .setLabel("Verify")
-      .setStyle("Success")
-      .setDisabled(true),
-    new ButtonBuilder()
-      .setCustomId("deny")
-      .setLabel("Deny")
-      .setStyle("Danger")
-      .setDisabled(true),
-    new ButtonBuilder()
-      .setCustomId("reasondeny")
-      .setLabel("Deny with reason")
-      .setStyle("Danger")
-      .setDisabled(true),
-    new ButtonBuilder()
-      .setCustomId("question")
-      .setLabel("Question")
-      .setStyle("Primary")
-      .setDisabled(true),
-    new ButtonBuilder()
-      .setCustomId("action")
-      .setLabel("Kick")
-      .setStyle("Secondary")
-      .setDisabled(true),
-  );
+  // const disverify = new ActionRowBuilder().addComponents(
+  //   new ButtonBuilder()
+  //     .setCustomId("verify")
+  //     .setLabel("Verify")
+  //     .setStyle("Success")
+  //     .setDisabled(true),
+  //   new ButtonBuilder()
+  //     .setCustomId("deny")
+  //     .setLabel("Deny")
+  //     .setStyle("Danger")
+  //     .setDisabled(true),
+  //   new ButtonBuilder()
+  //     .setCustomId("reasondeny")
+  //     .setLabel("Deny with reason")
+  //     .setStyle("Danger")
+  //     .setDisabled(true),
+  //   new ButtonBuilder()
+  //     .setCustomId("question")
+  //     .setLabel("Question")
+  //     .setStyle("Primary")
+  //     .setDisabled(true),
+  //   new ButtonBuilder()
+  //     .setCustomId("action")
+  //     .setLabel("Kick")
+  //     .setStyle("Secondary")
+  //     .setDisabled(true),
+  // );
 
   const serverConfig = await ServerConfig.findOne({
     where: { server_id: interaction.guild.id },
@@ -81,12 +81,13 @@ module.exports = async ({ interaction, client, userid, context }) => {
   });
   const messageids = verification?.guildVerifications?.[interaction.guild.id];
 
-  if (interaction.message.flags.has(MessageFlags.IsComponentsV2)) {
-    const originalContainer = interaction.message.components[0];
-    interaction.editReply({ components: [originalContainer, disverify] });
-  } else {
-    await interaction.editReply({ components: [disverify] });
-  }
+  // if (interaction.message.flags.has(MessageFlags.IsComponentsV2)) {
+  //   const originalContainer = interaction.message.components[0];
+  //   console.log('editing v2 container');
+  //   await interaction.editReply({ components: [originalContainer, disverify] });
+  // } else {
+  //   await interaction.editReply({ components: [disverify] });
+  // }
 
   if (
     serverConfig.verifylogs &&
@@ -217,6 +218,7 @@ module.exports = async ({ interaction, client, userid, context }) => {
         interaction.message,
       );
 
+      console.log('editing v2 container');
       await interaction.editReply({
         flags: [MessageFlags.IsComponentsV2],
         components: [verifiedContainer],

--- a/button_commands/verifyconfirm.js
+++ b/button_commands/verifyconfirm.js
@@ -1,6 +1,6 @@
 const {
-  ButtonBuilder,
-  ActionRowBuilder,
+  // ButtonBuilder,
+  // ActionRowBuilder,
   EmbedBuilder,
   AttachmentBuilder,
   MessageFlags,
@@ -29,33 +29,33 @@ module.exports = async ({ interaction, client, userid, context }) => {
     throw new Error("Could not fetch user ID from the embed");
   }
 
-  const disverify = new ActionRowBuilder().addComponents(
-    new ButtonBuilder()
-      .setCustomId("verify")
-      .setLabel("Verify")
-      .setStyle("Success")
-      .setDisabled(true),
-    new ButtonBuilder()
-      .setCustomId("deny")
-      .setLabel("Deny")
-      .setStyle("Danger")
-      .setDisabled(true),
-    new ButtonBuilder()
-      .setCustomId("reasondeny")
-      .setLabel("Deny with reason")
-      .setStyle("Danger")
-      .setDisabled(true),
-    new ButtonBuilder()
-      .setCustomId("question")
-      .setLabel("Question")
-      .setStyle("Primary")
-      .setDisabled(true),
-    new ButtonBuilder()
-      .setCustomId("action")
-      .setLabel("Kick")
-      .setStyle("Secondary")
-      .setDisabled(true),
-  );
+  // const disverify = new ActionRowBuilder().addComponents(
+  //   new ButtonBuilder()
+  //     .setCustomId("verify")
+  //     .setLabel("Verify")
+  //     .setStyle("Success")
+  //     .setDisabled(true),
+  //   new ButtonBuilder()
+  //     .setCustomId("deny")
+  //     .setLabel("Deny")
+  //     .setStyle("Danger")
+  //     .setDisabled(true),
+  //   new ButtonBuilder()
+  //     .setCustomId("reasondeny")
+  //     .setLabel("Deny with reason")
+  //     .setStyle("Danger")
+  //     .setDisabled(true),
+  //   new ButtonBuilder()
+  //     .setCustomId("question")
+  //     .setLabel("Question")
+  //     .setStyle("Primary")
+  //     .setDisabled(true),
+  //   new ButtonBuilder()
+  //     .setCustomId("action")
+  //     .setLabel("Kick")
+  //     .setStyle("Secondary")
+  //     .setDisabled(true),
+  // );
 
   const serverConfig = await ServerConfig.findOne({
     where: { server_id: interaction.guild.id },
@@ -155,12 +155,12 @@ module.exports = async ({ interaction, client, userid, context }) => {
   }
 
   //disable buttons
-  if (interaction.message.flags.has(MessageFlags.IsComponentsV2)) {
-    const originalContainer = interaction.message.components[0];
-    await interaction.editReply({ components: [originalContainer, disverify] });
-  } else {
-    await interaction.editReply({ components: [disverify] });
-  }
+  // if (interaction.message.flags.has(MessageFlags.IsComponentsV2)) {
+  //   const originalContainer = interaction.message.components[0];
+  //   await interaction.editReply({ components: [originalContainer, disverify] });
+  // } else {
+  //   await interaction.editReply({ components: [disverify] });
+  // }
 
   //send welcome message
   if (welcomeChannel !== null && welcomeMessage !== null) {

--- a/js/ErrorHandling.js
+++ b/js/ErrorHandling.js
@@ -240,20 +240,17 @@ class ErrorHandler {
       this.errorStats.clear();
 
       if (global.gc) {
-        for (let i = 0; i < 3; i++) {
-          global.gc();
-          await new Promise((resolve) => setTimeout(resolve, 100));
-        }
+        global.gc();
       }
 
       try {
         const owner = await client.users.fetch("808738877945675786");
         await owner.send(
-          `🚨 **CRITICAL MEMORY ERROR** 🚨\nBot had to perform emergency cleanup. Error: ${error.message}`,
+          `Bot had to perform emergency cleanup. Error: ${error.message}`,
         );
       } catch (err) {
         console.error(
-          "Failed to notify owner about critical memory error:",
+          "Failed to notify owner about memory error:",
           err.message,
         );
       }

--- a/js/MemoryManager.js
+++ b/js/MemoryManager.js
@@ -2,7 +2,7 @@ class MemoryManager {
   constructor(client) {
     this.client = client;
     this.cleanupInterval = 900000;
-    this.memoryThreshold = 450;
+    this.memoryThreshold = 400;
     this.emergencyThreshold = 500;
     this.lastCleanup = 0;
     this.stats = {
@@ -46,10 +46,6 @@ class MemoryManager {
 
       if (this.client.commandLoader?.clearCache) {
         this.client.commandLoader.clearCache();
-      }
-
-      if (global.gc) {
-        global.gc();
       }
 
       this.lastCleanup = Date.now();

--- a/js/artleaderboardweek.js
+++ b/js/artleaderboardweek.js
@@ -170,6 +170,7 @@ module.exports = async (client) => {
   });
 
   async function resetleaderboard(guild, client) {
+    let canvas, ctx, n1, n2, n3, frame, gold, silver, bronze;
     if (shouldSkipProcessing(guild.id, client.user.id)) return;
 
     const config = await ArtBoardConfig.findOne({
@@ -228,6 +229,7 @@ module.exports = async (client) => {
       async function fetchImage(artchannels, messageId) {
         for (const channelId of artchannels) {
           try {
+
             const channel = await client.channels.fetch(channelId, {
               force: true,
             });
@@ -311,22 +313,22 @@ module.exports = async (client) => {
       console.log("4");
 
       const Canvas = require("canvas");
-      const canvas = Canvas.createCanvas(1920, 1080);
-      const ctx = canvas.getContext("2d");
+      canvas = Canvas.createCanvas(1920, 1080);
+      ctx = canvas.getContext("2d");
       const background = await Canvas.loadImage(
         "./leaderboardimages/gallery2.png",
       );
 
       console.log(topPlaces);
 
-      const n1 = await Canvas.loadImage(topPlaces[0].image.url.toString());
-      const n2 = await Canvas.loadImage(topPlaces[1].image.url.toString());
-      const n3 = await Canvas.loadImage(topPlaces[2].image.url.toString());
+      n1 = await Canvas.loadImage(topPlaces[0].image.url.toString());
+      n2 = await Canvas.loadImage(topPlaces[1].image.url.toString());
+      n3 = await Canvas.loadImage(topPlaces[2].image.url.toString());
 
-      const frame = await Canvas.loadImage("./leaderboardimages/artframe.png");
-      const gold = await Canvas.loadImage("./leaderboardimages/gold2.png");
-      const silver = await Canvas.loadImage("./leaderboardimages/silver2.png");
-      const bronze = await Canvas.loadImage("./leaderboardimages/bronze2.png");
+      frame = await Canvas.loadImage("./leaderboardimages/artframe.png");
+      gold = await Canvas.loadImage("./leaderboardimages/gold2.png");
+      silver = await Canvas.loadImage("./leaderboardimages/silver2.png");
+      bronze = await Canvas.loadImage("./leaderboardimages/bronze2.png");
       const artist1 = await client.users.fetch(topPlaces[0].author);
       const artist2 = await client.users.fetch(topPlaces[1].author);
       const artist3 = await client.users.fetch(topPlaces[2].author);
@@ -582,6 +584,24 @@ module.exports = async (client) => {
           "\n```",
       );
       console.error("Error resetting leaderboard:", error);
+    } finally {
+      if (canvas) {
+        canvas.width = 0;
+        canvas.height = 0;
+        canvas = null;
+      }      
+      if (ctx) ctx = null;
+      if (n1) n1 = null;
+      if (n2) n2 = null;
+      if (n3) n3 = null;
+      if (frame) frame = null;
+      if (gold) gold = null;
+      if (silver) silver = null;
+      if (bronze) bronze = null;
+      
+      if (global.gc) {
+        global.gc();
+      }
     }
   }
 
@@ -606,7 +626,7 @@ module.exports = async (client) => {
             console.log("resetting novaguild leaderboard");
             resetleaderboard(novaguild, client);
           }
-        });
+        }, 5000);
       }
 
       if (client.user.id === "1291000170032402433") {

--- a/modal_commands/denyModal.js
+++ b/modal_commands/denyModal.js
@@ -1,6 +1,6 @@
 const {
-  ButtonBuilder,
-  ActionRowBuilder,
+  // ButtonBuilder,
+  // ActionRowBuilder,
   EmbedBuilder,
   MessageFlags,
   ContainerBuilder,
@@ -14,33 +14,33 @@ const {
 const { Verification, ServerConfig } = require("../dbObjects.js");
 
 module.exports = async ({ interaction, client, userid }) => {
-  const disverify = new ActionRowBuilder().addComponents(
-    new ButtonBuilder()
-      .setCustomId("verify")
-      .setLabel("Verify")
-      .setStyle("Success")
-      .setDisabled(true),
-    new ButtonBuilder()
-      .setCustomId("deny")
-      .setLabel("Deny")
-      .setStyle("Danger")
-      .setDisabled(true),
-    new ButtonBuilder()
-      .setCustomId("reasondeny")
-      .setLabel("Deny with reason")
-      .setStyle("Danger")
-      .setDisabled(true),
-    new ButtonBuilder()
-      .setCustomId("question")
-      .setLabel("Question")
-      .setStyle("Primary")
-      .setDisabled(true),
-    new ButtonBuilder()
-      .setCustomId("action")
-      .setLabel("Kick")
-      .setStyle("Secondary")
-      .setDisabled(true),
-  );
+  // const disverify = new ActionRowBuilder().addComponents(
+  //   new ButtonBuilder()
+  //     .setCustomId("verify")
+  //     .setLabel("Verify")
+  //     .setStyle("Success")
+  //     .setDisabled(true),
+  //   new ButtonBuilder()
+  //     .setCustomId("deny")
+  //     .setLabel("Deny")
+  //     .setStyle("Danger")
+  //     .setDisabled(true),
+  //   new ButtonBuilder()
+  //     .setCustomId("reasondeny")
+  //     .setLabel("Deny with reason")
+  //     .setStyle("Danger")
+  //     .setDisabled(true),
+  //   new ButtonBuilder()
+  //     .setCustomId("question")
+  //     .setLabel("Question")
+  //     .setStyle("Primary")
+  //     .setDisabled(true),
+  //   new ButtonBuilder()
+  //     .setCustomId("action")
+  //     .setLabel("Kick")
+  //     .setStyle("Secondary")
+  //     .setDisabled(true),
+  // );
 
   if (userid && userid.includes(" | ")) {
     await interaction.reply({
@@ -54,12 +54,12 @@ module.exports = async ({ interaction, client, userid }) => {
 
   await interaction.deferUpdate();
   //disable buttons without changing the other components
-  if (interaction.message.flags.has(MessageFlags.IsComponentsV2)) {
-    const originalContainer = interaction.message.components[0];
-    interaction.editReply({ components: [originalContainer, disverify] });
-  } else {
-    await interaction.editReply({ components: [disverify] });
-  }
+  // if (interaction.message.flags.has(MessageFlags.IsComponentsV2)) {
+  //   const originalContainer = interaction.message.components[0];
+  //   interaction.editReply({ components: [originalContainer, disverify] });
+  // } else {
+  //   await interaction.editReply({ components: [disverify] });
+  // }
 
   const verification = await Verification.findOne({
     where: { userId: userid },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "nodemon index.js",
-    "start": "node index.js",
+    "start": "node index.js --expose-gc",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   },


### PR DESCRIPTION
when doing an action on a verification, this error is likely happening because of the first editReply (that turns the buttons gray) due to some delay executes after the deny has already been handled, and thus showing the grayed-out buttons instead of showing the "completed" form. This should be fixed by just completely removing the graying of the buttons, since it is kind of redundant as in most cases the buttons get removed directly afterwards anyways, so saves some API calls too.