### PR TITLE
Clean old image logic

### DIFF
--- a/button_commands/setupbuttons/finishsetup.js
+++ b/button_commands/setupbuttons/finishsetup.js
@@ -1,13 +1,8 @@
 const {
-  ButtonBuilder,
-  ActionRowBuilder,
   EmbedBuilder,
-  AttachmentBuilder,
   MessageFlags,
 } = require("discord.js");
 const { Application } = require("../../dbObjects.js");
-const fs = require("fs");
-const path = require("path");
 const {
   deleteTempApplication,
   getApplicationById,
@@ -19,6 +14,7 @@ const {
   purgeOldImages,
   isR2ImageResource,
 } = require("../../js/customizationImages.js");
+const { updateVerifyMessage } = require("../../js/verifyChannelUtils.js");
 
 module.exports = async ({ interaction, client, context }) => {
   const tempApplicationId = context[0] === "firsttime" ? parseInt(context[1], 10) : parseInt(context[0], 10);
@@ -125,18 +121,6 @@ module.exports = async ({ interaction, client, context }) => {
     if (isR2ImageResource(tempApp[category]?.image)) {
       continue;
     }
-
-    if (tempApp[category]?.image) {
-      const imagePath = path.join(__dirname, "..", "..", tempApp[category].image);
-      try {
-        await fs.promises.access(imagePath, fs.constants.F_OK);
-        console.log(`Image exists: ${imagePath}`);
-      } catch {
-        console.error(`Image not found: ${imagePath}`);
-        tempApp[category].image = null;
-        throw new Error(`Image not found: ${imagePath}`);
-      }
-    }
   }
 
   const appData = { server_id: interaction.guild.id, name: tempApp.name };
@@ -188,75 +172,27 @@ module.exports = async ({ interaction, client, context }) => {
     });
   }
 
-  const verificationMessages = await verifyChannelObj.messages.fetch();
-  const verificationMessage = verificationMessages.find(
-    (m) =>
-      m.author.id === client.user.id &&
-      m.embeds.length > 0 &&
-      m.embeds[0].footer &&
-      m.embeds[0].footer.text === `${tempApp.name}`,
-  );
-
   const embedColor = (tempApp.verifychannelembed?.color ?? existingApp?.verifychannelembed?.color) || "#3f7ff1";
   const embedTitle = tempApp.verifychannelembed?.title ?? existingApp?.verifychannelembed?.title ?? "Verification";
   const embedDescription = tempApp.verifychannelembed?.description ?? existingApp?.verifychannelembed?.description ?? "Please verify yourself by clicking the button below.";
   const embedImage = tempApp.verifychannelembed?.image ?? existingApp?.verifychannelembed?.image;
-  const embedImageAsset = resolveImage(embedImage, "verifychannelimage");
+  const embedImageAsset = resolveImage(embedImage);
 
-  if (!verificationMessage) {
-    const verificationembed = new EmbedBuilder()
-      .setColor(embedColor)
-      .setTitle(embedTitle)
-      .setDescription(embedDescription)
-      .setImage(embedImageAsset.embedUrl)
-      .setFooter({ text: `${tempApp.name}` });
-
-    const row = new ActionRowBuilder().addComponents(
-      new ButtonBuilder()
-        .setCustomId(`verifybutton_${finalApp.id}`)
-        .setLabel("Apply")
-        .setStyle("Success"),
-    );
-
-    let attachment;
-    if (embedImageAsset.filePath) {
-      attachment = new AttachmentBuilder(embedImageAsset.filePath).setName(
-        embedImageAsset.attachmentName,
-      );
-    }
-
-    await verifyChannelObj.send({
-      embeds: [verificationembed],
-      components: [row],
-      files: attachment ? [attachment] : [],
-    });
-  } else {
-    const verifymessageEmbed = new EmbedBuilder(verificationMessage.embeds[0])
-      .setColor(embedColor)
-      .setTitle(embedTitle)
-      .setDescription(embedDescription)
-      .setImage(embedImageAsset.embedUrl)
-      .setFooter({ text: `${tempApp.name}` });
-
-    let attachment;
-    if (embedImageAsset.filePath) {
-      attachment = new AttachmentBuilder(embedImageAsset.filePath).setName(
-        embedImageAsset.attachmentName,
-      );
-    }
-
-    if (
-      verificationMessage.embeds[0].title !== verifymessageEmbed.title ||
-      verificationMessage.embeds[0].description !== verifymessageEmbed.description ||
-      verificationMessage.embeds[0].image?.url !== verifymessageEmbed.image?.url ||
-      verificationMessage.embeds[0].color !== verifymessageEmbed.color
-    ) {
-      await verificationMessage.edit({
-        embeds: [verifymessageEmbed],
-        files: attachment ? [attachment] : [],
-      });
-    }
-  }
+  await updateVerifyMessage({
+    verifyChannelObj,
+    botId: client.user.id,
+    embedConfig: {
+      color: embedColor,
+      title: embedTitle,
+      description: embedDescription,
+      imageUrl: embedImageAsset.embedUrl,
+      footer: tempApp.name,
+    },
+    button: {
+      customId: `verifybutton_${finalApp.id}`,
+      label: "Apply",
+    },
+  });
 
   await deleteTempApplication(interaction.guild.id, { id: tempApplicationId });
 

--- a/button_commands/verifybutton.js
+++ b/button_commands/verifybutton.js
@@ -6,7 +6,6 @@ const {
   ButtonBuilder,
   ActionRowBuilder,
   EmbedBuilder,
-  AttachmentBuilder,
   PermissionsBitField,
   MessageFlags,
   ContainerBuilder,
@@ -229,7 +228,7 @@ module.exports = async ({ interaction, client, applicationId }) => {
         interaction.guild.name,
       );
       const startEmbedimage = application.startmessage?.image;
-      const startImageAsset = resolveImage(startEmbedimage, "startImage");
+      const startImageAsset = resolveImage(startEmbedimage);
 
       const startDMEmbed = new EmbedBuilder()
         .setTitle(
@@ -237,27 +236,20 @@ module.exports = async ({ interaction, client, applicationId }) => {
         )
         .setDescription(startEmbedDescription ?? null)
         .setColor("#3f7ff1")
-        .setFooter({ 
+        .setFooter({
           text: `Application: ${appName} | Click "cancel" to cancel the verification.`
         })
         .setImage(startImageAsset.embedUrl);
 
       let firstQuestionEmbed = new EmbedBuilder()
         .setColor("#3f7ff1")
-        .setFooter({ 
+        .setFooter({
           text: `Application: ${appName} | Click "cancel" to cancel the verification.`
         });
 
       try {
         await dmChannel.send({
           embeds: [startDMEmbed],
-          files: startImageAsset.filePath
-            ? [
-                new AttachmentBuilder(startImageAsset.filePath).setName(
-                  startImageAsset.attachmentName,
-                ),
-              ]
-            : [],
         });
       } catch (error) {
         if (error.code === 50007) {
@@ -1034,10 +1026,7 @@ async function processVerificationResult(
       interaction.guild.name,
     );
       const finishEmbedimage = finishmessage?.image;
-      const finishImageAsset = resolveImage(
-        finishEmbedimage,
-        "finishImage",
-      );
+      const finishImageAsset = resolveImage(finishEmbedimage);
 
     const endEmbed = new EmbedBuilder()
       .setTitle(
@@ -1046,17 +1035,10 @@ async function processVerificationResult(
       .setDescription(finishEmbedDescription)
       .setColor("#008000")
       .setFooter({ text: `Application: ${appName}` })
-        .setImage(finishImageAsset.embedUrl);
+      .setImage(finishImageAsset.embedUrl);
 
     dmChannel.send({
       embeds: [endEmbed],
-        files: finishImageAsset.filePath
-          ? [
-            new AttachmentBuilder(finishImageAsset.filePath).setName(
-              finishImageAsset.attachmentName,
-            ),
-          ]
-          : [],
     });
 
     user = user || interaction.user;

--- a/js/imageUtils.js
+++ b/js/imageUtils.js
@@ -1,53 +1,24 @@
-const fs = require("node:fs");
-const path = require("node:path");
 const { getPublicUrl } = require("./customizationImages.js");
 
-const resolveAbsolutePath = (imagePath) => {
-  if (!imagePath) {
-    return null;
-  }
-  if (path.isAbsolute(imagePath)) {
-    return imagePath;
-  }
-  return path.join(process.cwd(), imagePath);
-};
-
-const resolveImage = (image, fallbackName = "image") => {
+const resolveImage = (image) => {
   if (!image) {
     return {
       embedUrl: null,
-      filePath: null,
-      attachmentName: null,
-      isRemote: false,
     };
   }
 
   if (typeof image === "object" && (image.url || image.key)) {
     const embedUrl = image.url || getPublicUrl(image.key);
-    const extensionFromMeta = image.extension || path.extname(image.key || "").slice(1) || "png";
     return {
       embedUrl,
-      filePath: null,
-      attachmentName: `${fallbackName}.${extensionFromMeta}`,
-      isRemote: true,
     };
   }
 
-  const absolutePath = resolveAbsolutePath(image);
-  if (!absolutePath || !fs.existsSync(absolutePath)) {
-    return {
-      embedUrl: null,
-      filePath: null,
-      attachmentName: null,
-      isRemote: false,
-    };
-  }
+  return {
+    embedUrl: null,
+  };
 };
-
-const isRemoteImage = (image) =>
-  Boolean(image && typeof image === "object" && (image.url || image.key));
 
 module.exports = {
   resolveImage,
-  isRemoteImage,
 };

--- a/js/verificationHandler.js
+++ b/js/verificationHandler.js
@@ -1,6 +1,5 @@
 const {
   EmbedBuilder,
-  AttachmentBuilder,
   MessageFlags,
   ContainerBuilder,
   TextDisplayBuilder,
@@ -300,16 +299,11 @@ async function sendWelcomeMessage(interaction, user, welcomeChannel, welcomeMess
       originalEmbed,
       verifiedRoles,
     );
-    const textImage = resolveImage(welcomeMessage.image, "welcomemessage");
+    const textImage = resolveImage(welcomeMessage.image);
 
-    const files = [];
-    if (textImage.filePath) {
-      files.push(new AttachmentBuilder(textImage.filePath).setName(textImage.attachmentName));
-    }
+    const finalmessage = { content: finalText };
 
-    const finalmessage = { content: finalText, files };
-
-    if (!textImage.filePath && textImage.embedUrl) {
+    if (textImage.embedUrl) {
       finalmessage.embeds = [new EmbedBuilder().setImage(textImage.embedUrl)];
     }
 
@@ -323,7 +317,7 @@ async function sendWelcomeMessage(interaction, user, welcomeChannel, welcomeMess
       : null;
     const messageContent = getMentions(finalDescription);
 
-    const imageAsset = resolveImage(welcomeMessage.image, "welcomemessage");
+    const imageAsset = resolveImage(welcomeMessage.image);
 
     const welcomeEmbed = new EmbedBuilder()
       .setTitle(finalTitle && finalTitle.trim() ? finalTitle : null)
@@ -343,9 +337,6 @@ async function sendWelcomeMessage(interaction, user, welcomeChannel, welcomeMess
     await channel.send({
       content: messageContent || null,
       embeds: [welcomeEmbed],
-      files: imageAsset.filePath
-        ? [new AttachmentBuilder(imageAsset.filePath).setName(imageAsset.attachmentName)]
-        : [],
     });
   }
 }
@@ -358,7 +349,7 @@ async function sendVerifyDM(user, application, interaction, verifiedRoles) {
 
   const finalTitle = await processText(title, user, interaction, null, verifiedRoles);
   const finalDescription = await processText(description, user, interaction, null, verifiedRoles);
-  const dmImage = resolveImage(image, "verifymessage");
+  const dmImage = resolveImage(image);
 
   const finalEmbed = new EmbedBuilder()
     .setTitle(finalTitle ?? null)
@@ -368,9 +359,6 @@ async function sendVerifyDM(user, application, interaction, verifiedRoles) {
 
   await user.send({
     embeds: [finalEmbed],
-    files: dmImage.filePath
-      ? [new AttachmentBuilder(dmImage.filePath).setName(dmImage.attachmentName)]
-      : [],
   }).catch(() => {});
 }
 

--- a/js/verifyChannelUtils.js
+++ b/js/verifyChannelUtils.js
@@ -1,0 +1,93 @@
+const {
+  EmbedBuilder,
+  ActionRowBuilder,
+  ButtonBuilder,
+} = require("discord.js");
+
+async function findVerifyMessage(verifyChannelObj, botId, embedConfig) {
+  const verificationMessages = await verifyChannelObj.messages.fetch({
+    limit: 50,
+  });
+  return verificationMessages.find(
+    (m) =>
+      m.author.id === botId &&
+      m.embeds.length > 0 &&
+      m.embeds[0].footer &&
+      m.embeds[0].footer.text === embedConfig.footer,
+  );
+}
+
+function messageNeedsUpdate(existingMessage, newEmbed) {
+  const oldEmbed = existingMessage.embeds[0];
+  const newEmbedData = newEmbed.data;
+
+  return (
+    (oldEmbed.title || null) !== (newEmbedData.title || null) ||
+    (oldEmbed.description || null) !== (newEmbedData.description || null) ||
+    oldEmbed.image?.url !== newEmbedData.image?.url ||
+    oldEmbed.color !== newEmbedData.color
+  );
+}
+
+async function updateVerifyMessage(opts) {
+  const {
+    verifyChannelObj,
+    botId,
+    embedConfig,
+    button,
+  } = opts;
+
+  const verificationMessage = await findVerifyMessage(
+    verifyChannelObj,
+    botId,
+    embedConfig.footer,
+  );
+
+  const embed = new EmbedBuilder()
+    .setColor(embedConfig.color)
+    .setTitle(embedConfig.title)
+    .setDescription(embedConfig.description)
+    .setImage(embedConfig.imageUrl)
+    .setFooter({ text: embedConfig.footer });
+
+  const row = new ActionRowBuilder().addComponents(
+    new ButtonBuilder()
+      .setCustomId(button.customId)
+      .setLabel(button.label)
+      .setStyle("Success"),
+  );
+
+  if (!verificationMessage) {
+    // Create new message
+    const newMessage = await verifyChannelObj.send({
+      embeds: [embed],
+      components: [row],
+    });
+
+    return {
+      action: "created",
+      message: newMessage,
+    };
+  } else {
+    // Check if update needed
+    if (messageNeedsUpdate(verificationMessage, embed)) {
+      await verificationMessage.edit({
+        embeds: [embed],
+      });
+
+      return {
+        action: "updated",
+        message: verificationMessage,
+      };
+    }
+
+    return {
+      action: "no_changes",
+      message: verificationMessage,
+    };
+  }
+}
+
+module.exports = {
+  updateVerifyMessage,
+};

--- a/menu_commands/selectcustomizationMenu.js
+++ b/menu_commands/selectcustomizationMenu.js
@@ -4,7 +4,6 @@ const {
   EmbedBuilder,
   StringSelectMenuBuilder,
   ButtonStyle,
-  AttachmentBuilder,
   MessageFlags,
 } = require("discord.js");
 const { getApplicationById, getTempApplicationById } = require("../js/tempconfigfuncs.js");
@@ -168,20 +167,10 @@ module.exports = async ({ interaction, customIdValue, tempApplicationId, context
     infoembed.setColor("#3f7ff1");
   }
 
-  let attachment;
   if (image && embed) {
-    const asset = resolveImage(image, chosenvalue);
+    const asset = resolveImage(image);
     if (asset.embedUrl) {
       embed.setColor(color || "#3f7ff1").setImage(asset.embedUrl);
-    }
-    if (asset.filePath) {
-      try {
-        attachment = new AttachmentBuilder(asset.filePath).setName(
-          asset.attachmentName,
-        );
-      } catch (error) {
-        console.error("Error creating attachment:", error);
-      }
     }
   }
 
@@ -246,7 +235,6 @@ module.exports = async ({ interaction, customIdValue, tempApplicationId, context
           setImage,
           finishbuttons,
         ],
-        files: attachment ? [attachment] : [],
       });
     } else {
       interaction.message.edit({
@@ -258,7 +246,6 @@ module.exports = async ({ interaction, customIdValue, tempApplicationId, context
           setImage,
           finishbuttons,
         ],
-        files: attachment ? [attachment] : [],
       });
     }
   } else {
@@ -276,7 +263,6 @@ module.exports = async ({ interaction, customIdValue, tempApplicationId, context
           setImage,
           finishbuttons,
         ],
-        files: attachment ? [attachment] : [],
       });
     } else {
       interaction.update({
@@ -288,7 +274,6 @@ module.exports = async ({ interaction, customIdValue, tempApplicationId, context
           setImage,
           finishbuttons,
         ],
-        files: attachment ? [attachment] : [],
       });
     }
   }


### PR DESCRIPTION
Cleans up the old image logic which was used when images were stored locally instead of on a S3 storage server. Does keep commented out cleanup code in index.js as that could still be useful to reïmplement on startup with the S3 storage server (though this technically shouldn't be needed if cleanup logic on reset/delete works properly).