### PR TITLE
Fix verifyChannelUtils.js

### DIFF
--- a/js/verifyChannelUtils.js
+++ b/js/verifyChannelUtils.js
@@ -40,7 +40,7 @@ async function updateVerifyMessage(opts) {
   const verificationMessage = await findVerifyMessage(
     verifyChannelObj,
     botId,
-    embedConfig.footer,
+    embedConfig,
   );
 
   const embed = new EmbedBuilder()


### PR DESCRIPTION
embedConfig.footer should be embedConfig when calling the findVerifyMessage, since in findVerifyMessage it uses embedConfig.footer. 
Before it would just keep sending new verify messages because check would fail.