### PR TITLE
Update error catching to include discord API change

### DIFF
--- a/button_commands/answerquestion.js
+++ b/button_commands/answerquestion.js
@@ -87,10 +87,11 @@ module.exports = async ({ interaction, client }) => {
   );
 
   await message.edit({ components: [disabledconfirmrow] });
-  const sendanswer = await interaction.reply({
+  await interaction.reply({
     content: `Please send your answer to the question you just pressed "answer" to`,
     components: [cancelButton],
   });
+  const sendanswer = await interaction.fetchReply();
 
   await QuestionId.destroy({
     where: { interactionMessageId: interaction.message.id },

--- a/button_commands/verifybutton.js
+++ b/button_commands/verifybutton.js
@@ -252,7 +252,7 @@ module.exports = async ({ interaction, client, applicationId }) => {
           embeds: [startDMEmbed],
         });
       } catch (error) {
-        if (error.code === 50007) {
+        if (error.code === 50007 || error.code === 50278) {
           // Cannot send messages to this user
           await interaction.editReply({
             content: `<@${user.id}>, I cannot send you DMs! Please enable DMs from server members and try again.`,

--- a/js/verificationHandler.js
+++ b/js/verificationHandler.js
@@ -354,7 +354,7 @@ async function sendVerifyDM(user, application, interaction, verifiedRoles) {
   const finalEmbed = new EmbedBuilder()
     .setTitle(finalTitle ?? null)
     .setDescription(finalDescription)
-    .setColor(color)
+    .setColor(color ?? null)
     .setImage(dmImage.embedUrl);
 
   await user.send({
@@ -375,7 +375,7 @@ async function sendDenyDM(user, guildName, reason = null) {
     await user.send({ embeds: [denyEmbed] });
     return { success: true };
   } catch (error) {
-    if (error.code === 50007) {
+    if (error.code === 50007 || error.code === 50278) {
       return { success: false, dmDisabled: true };
     }
     throw error;

--- a/modal_commands/denyModal.js
+++ b/modal_commands/denyModal.js
@@ -269,7 +269,7 @@ module.exports = async ({ interaction, client, userid, applicationId }) => {
       flags: MessageFlags.Ephemeral,
     });
   } catch (error) {
-    if (error.code === 50007) {
+    if (error.code === 50007 || error.code === 50278) {
       await interaction.followUp({
         content: `✅ User denied successfully\n⚠️ Unable to send a DM as this user has their DMs disabled or has blocked the bot.`,
         flags: MessageFlags.Ephemeral,

--- a/modal_commands/questionModal.js
+++ b/modal_commands/questionModal.js
@@ -56,7 +56,7 @@ module.exports = async ({ interaction, client, userid, applicationId }) => {
       applicationId: applicationId,
     });
   } catch (error) {
-    if (error.code === 50007) {
+    if (error.code === 50007 || error.code === 50278) {
       return await interaction.reply({
         content: `Cannot send question: this user has DMs disabled, has blocked the bot or left the server.`,
         flags: MessageFlags.Ephemeral,


### PR DESCRIPTION
- Update error catching to include discord API change which has error 50278 as an error too if user couldn't be DMed.
- Fixed error where colro was invalid so it default to null incase of failing. (shouldn't be possible, but perhaps color input validation wasn't correct during setup, should be looked into)
- Fetches message at answerquestion instead of trying to send to the interaction endpoint itself as that can possibly result in 50027 error.