### PR TITLE
Fix review channel permission check

### DIFF
--- a/button_commands/verifybutton.js
+++ b/button_commands/verifybutton.js
@@ -168,7 +168,9 @@ module.exports = async ({ interaction, client, applicationId }) => {
       });
     }
 
-    const botPermissions = verifyLogsChannel.permissionsFor(client.user);
+    const botMember = interaction.guild.members.me ?? await interaction.guild.members.fetchMe();
+  
+    const botPermissions = verifyLogsChannel.permissionsFor(botMember);
     if (
       !botPermissions ||
       !botPermissions.has([


### PR DESCRIPTION
Changes permission check to get the guildmember of the bot by first trying the cache, and if it isn't in cached, fetch it. Should fix issue where error would be thrown falsely.