### PR TITLE
Change "Verify" button to "Accept"

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -315,7 +315,7 @@ async function createBot(token) {
   const disverify = new ActionRowBuilder().addComponents(
     new ButtonBuilder()
       .setCustomId("verify")
-      .setLabel("Verify")
+      .setLabel("Accept")
       .setStyle("Success")
       .setDisabled(true),
     new ButtonBuilder()

--- a/button_commands/returntomenu.js
+++ b/button_commands/returntomenu.js
@@ -10,7 +10,7 @@ module.exports = async ({ interaction, applicationId }) => {
   const verify = new ActionRowBuilder().addComponents(
     new ButtonBuilder()
       .setCustomId(`verify_${applicationId}`)
-      .setLabel("Verify")
+      .setLabel("Accept")
       .setStyle("Success"),
     new ButtonBuilder().setCustomId(`deny_${applicationId}`).setLabel("Deny").setStyle("Danger"),
     new ButtonBuilder()

--- a/button_commands/verifybutton.js
+++ b/button_commands/verifybutton.js
@@ -1059,7 +1059,7 @@ async function processVerificationResult(
     const verify = new ActionRowBuilder().addComponents(
       new ButtonBuilder()
         .setCustomId(`verify_${applicationId}_${interaction.user.id}`)
-        .setLabel("Verify")
+        .setLabel("Accept")
         .setStyle("Success"),
       new ButtonBuilder()
         .setCustomId(`deny_${applicationId}_${interaction.user.id}`)


### PR DESCRIPTION
Changes "Verify" button under applications/verifications to "Accept" button to be more uniform when being used for non-verification related applications (like staff applications).