### PR TITLE
Add valid hex check

### DIFF
--- a/button_commands/setupbuttons/finishsetup.js
+++ b/button_commands/setupbuttons/finishsetup.js
@@ -14,7 +14,7 @@ const {
   purgeOldImages,
   isR2ImageResource,
 } = require("../../js/customizationImages.js");
-const { updateVerifyMessage } = require("../../js/verifyChannelUtils.js");
+const { updateVerifyMessage, isValidHexColor } = require("../../js/verifyChannelUtils.js");
 
 module.exports = async ({ interaction, client, context }) => {
   const tempApplicationId = context[0] === "firsttime" ? parseInt(context[1], 10) : parseInt(context[0], 10);
@@ -172,7 +172,7 @@ module.exports = async ({ interaction, client, context }) => {
     });
   }
 
-  const embedColor = (tempApp.verifychannelembed?.color ?? existingApp?.verifychannelembed?.color) || "#3f7ff1";
+  const embedColor = isValidHexColor(tempApp.verifychannelembed?.color ?? existingApp?.verifychannelembed?.color) ? (tempApp.verifychannelembed?.color ?? existingApp?.verifychannelembed?.color) : "#3f7ff1";
   const embedTitle = tempApp.verifychannelembed?.title ?? existingApp?.verifychannelembed?.title ?? "Verification";
   const embedDescription = tempApp.verifychannelembed?.description ?? existingApp?.verifychannelembed?.description ?? "Please verify yourself by clicking the button below.";
   const embedImage = tempApp.verifychannelembed?.image ?? existingApp?.verifychannelembed?.image;

--- a/js/verifyChannelUtils.js
+++ b/js/verifyChannelUtils.js
@@ -4,6 +4,13 @@ const {
   ButtonBuilder,
 } = require("discord.js");
 
+const DEFAULT_EMBED_COLOR = "#3f7ff1";
+
+function isValidHexColor(value) {
+  const hexColorRegex = /^#?[0-9A-Fa-f]{6}$/;
+  return hexColorRegex.test(value)
+}
+
 async function findVerifyMessage(verifyChannelObj, botId, embedConfig) {
   const verificationMessages = await verifyChannelObj.messages.fetch({
     limit: 50,
@@ -44,7 +51,7 @@ async function updateVerifyMessage(opts) {
   );
 
   const embed = new EmbedBuilder()
-    .setColor(embedConfig.color)
+    .setColor(isValidHexColor(embedConfig.color) ? embedConfig.color : DEFAULT_EMBED_COLOR)
     .setTitle(embedConfig.title)
     .setDescription(embedConfig.description)
     .setImage(embedConfig.imageUrl)
@@ -90,4 +97,5 @@ async function updateVerifyMessage(opts) {
 
 module.exports = {
   updateVerifyMessage,
+  isValidHexColor
 };

--- a/menu_commands/selectcustomizationMenu.js
+++ b/menu_commands/selectcustomizationMenu.js
@@ -8,6 +8,7 @@ const {
 } = require("discord.js");
 const { getApplicationById, getTempApplicationById } = require("../js/tempconfigfuncs.js");
 const { resolveImage } = require("../js/imageUtils.js");
+const { isValidHexColor } = require("../js/verifyChannelUtils.js");
 
 module.exports = async ({ interaction, customIdValue, tempApplicationId, context }) => {
   let chosenvalue;
@@ -110,7 +111,7 @@ module.exports = async ({ interaction, customIdValue, tempApplicationId, context
     embed = new EmbedBuilder()
       .setTitle(title ?? null)
       .setDescription(description)
-      .setColor(color || "#3f7ff1");
+      .setColor(isValidHexColor(color) ? color : "#3f7ff1");
   }
 
   let infoembed = null;
@@ -170,7 +171,7 @@ module.exports = async ({ interaction, customIdValue, tempApplicationId, context
   if (image && embed) {
     const asset = resolveImage(image);
     if (asset.embedUrl) {
-      embed.setColor(color || "#3f7ff1").setImage(asset.embedUrl);
+      embed.setColor(isValidHexColor(color) ? color : "#3f7ff1").setImage(asset.embedUrl);
     }
   }
 


### PR DESCRIPTION
- Adds valid hex color check which makes sure a hex code is actually valid before trying to use it to create embeds.
- Also fixes soft lock which would happen if there was an invalid hex saved to configuration, causing it to not be able to open the configuration again because discord would throw an error that the hexcolour is invalid.