### PR TITLE
Handle too long applications and refactor

### DIFF
--- a/button_commands/action.js
+++ b/button_commands/action.js
@@ -1,10 +1,10 @@
 const {
   ButtonBuilder,
   ActionRowBuilder,
-  EmbedBuilder,
   MessageFlags,
 } = require("discord.js");
 const { getApplicationByIdWithFallback } = require("../js/tempconfigfuncs.js"); //the fallback is temporary for migration since button ids aren't updated into the past.
+const { relinkAttachments } = require("../js/verificationHandler.js");
 
 module.exports = async ({ interaction, applicationId }) => {
   await interaction.deferUpdate();
@@ -67,19 +67,12 @@ module.exports = async ({ interaction, applicationId }) => {
   );
 
   if (hasComponents) {
-    await interaction.message.edit({
+    const { container, files } = relinkAttachments(interaction.message);
+    const editPayload = {
       flags: [MessageFlags.IsComponentsV2],
-      components: [originalComponents[0], verifyRow],
-    });
-  } else {
-    const verifyEmbed = new EmbedBuilder(originalEmbed).addFields({
-      name: "Are you sure you want to kick this user?",
-      value: 'Click "Confirm Verification" to kick or "Cancel" to return.',
-    });
-
-    await interaction.message.edit({
-      embeds: [verifyEmbed],
-      components: [verifyRow],
-    });
+      components: [container, verifyRow],
+    };
+    if (files) editPayload.files = files;
+    await interaction.message.edit(editPayload);
   }
 };

--- a/button_commands/actionconfirm.js
+++ b/button_commands/actionconfirm.js
@@ -2,15 +2,16 @@ const {
   EmbedBuilder,
   PermissionsBitField,
   MessageFlags,
-  ContainerBuilder,
-  TextDisplayBuilder,
-  SeparatorBuilder,
-  SeparatorSpacingSize,
-  MediaGalleryBuilder,
-  SectionBuilder,
-  ThumbnailBuilder,
 } = require("discord.js");
 const { Verification } = require("../dbObjects.js");
+const {
+  checkManagerPermission,
+  handleV2Edit,
+  VerificationStatus,
+  relinkAttachments,
+  processLogMessages,
+  cleanupVerificationData,
+} = require("../js/verificationHandler.js");
 const { getApplicationByIdWithFallback } = require("../js/tempconfigfuncs.js");
 
 module.exports = async ({ interaction, client, userid, context, applicationId }) => {
@@ -37,18 +38,13 @@ module.exports = async ({ interaction, client, userid, context, applicationId })
     });
   }
 
-  if (application && Array.isArray(application.managerrole) && application.managerrole.length > 0) {
-    const member = await interaction.guild.members.fetch(interaction.user.id);
-    const hasManagerRole = application.managerrole.some((role) =>
-      member.roles.cache.has(role),
-    );
-
-    if (!hasManagerRole) {
-      return interaction.followUp({
-        content: `You do not have permission to manage verifications. You need one of the following roles: ${application.managerrole?.map((role) => `<@&${role}>`).join(", ")}`,
-        flags: MessageFlags.Ephemeral,
-      });
-    }
+  // Check manager permissions
+  const permCheck = await checkManagerPermission(interaction, application);
+  if (!permCheck.allowed) {
+    return interaction.followUp({
+      content: permCheck.message,
+      flags: MessageFlags.Ephemeral,
+    });
   }
 
   const user = await client.users.fetch(userid);
@@ -119,278 +115,55 @@ module.exports = async ({ interaction, client, userid, context, applicationId })
   });
   const messageids = verification?.guildVerifications?.[interaction.guild.id];
 
-  if (
-    application?.verifylogs &&
-    messageids &&
-    application.reviewchannel !== application.verifylogs
-  ) {
-    const reviewChannel = interaction.guild.channels.cache.get(
-      application.reviewchannel,
-    );
-    const logChannel = interaction.guild.channels.cache.get(
-      application.verifylogs,
-    );
-
-    if (logChannel && reviewChannel && messageids) {
-      const messages = [];
-      for (const messageId of messageids) {
-        try {
-          await new Promise((resolve) => setTimeout(resolve, 300));
-          const message = await reviewChannel.messages.fetch(messageId);
-          if (message) messages.push(message);
-        } catch (error) {
-          if (error.code === 10008) {
-            console.log(`Message ${messageId} not found - skipping`);
-            continue;
-          }
-          throw error;
-        }
-      }
-
-      // Sort by timestamp
-      messages.sort((a, b) => a.createdTimestamp - b.createdTimestamp);
-
-      // Send modified embeds to logs and delete from review
-      for (const message of messages) {
-        await new Promise((resolve) => setTimeout(resolve, 600));
-
-        if (message.flags.has(MessageFlags.IsComponentsV2)) {
-          const verifiedContainer = await handleV2edit(interaction, message);
-
-          let threadEmbed;
-
-          if (message.thread) {
-            threadEmbed = new EmbedBuilder()
-              .setTitle(`Thread Summary`)
-              .setColor("#EB2121");
-
-            try {
-              const threadMessages = await message.thread.messages.fetch();
-
-              if (threadMessages.size > 1) {
-                const messagesArray = Array.from(threadMessages.values())
-                  .sort((a, b) => a.createdTimestamp - b.createdTimestamp)
-                  .slice(1);
-
-                const formattedMessages = messagesArray?.map((msg) => {
-                  let content;
-
-                  if (msg.flags.has(MessageFlags.IsComponentsV2)) {
-                    content =
-                      msg.components?.[0]?.components?.[0]?.content ||
-                      "No content";
-                  } else {
-                    content = msg.content || "No content";
-                  }
-
-                  if (msg.author.id === client.user.id) {
-                    content = content?.replace(
-                      /### Question answered by[^\n]*\n?/g,
-                      "\n",
-                    );
-                  }
-
-                  return `\`${msg.author.username}:\` ${content}`;
-                });
-
-                const finalContent = formattedMessages
-                  .join("\n")
-                  .slice(0, 4096);
-                threadEmbed.setDescription(
-                  finalContent || "No messages in thread",
-                );
-              } else {
-                threadEmbed.setDescription("No additional messages in thread");
-              }
-            } catch (error) {
-              console.error("Error fetching thread messages:", error);
-              threadEmbed.setDescription("Error loading thread messages");
-            }
-          }
-
-          let sendmessage = await logChannel.send({
-            flags: [MessageFlags.IsComponentsV2],
-            components: [verifiedContainer],
-          });
-
-          let threadchannel = await sendmessage.startThread({
-            name: `${user.username}'s log`,
-          });
-
-          if (threadEmbed) {
-            await threadchannel.send({ embeds: [threadEmbed] });
-          }
-          await threadchannel.setArchived(true);
-          if (interaction.message.thread) {
-            await interaction.message.thread.delete();
-          }
-
-          await message.delete().catch(console.error);
-        } else {
-          let originalembed = message.embeds[0];
-
-          let Embed = new EmbedBuilder(originalembed)
-            .setColor("#EB2121")
-            .setTitle(originalembed.title + " (KICKED)")
-            .setFooter({
-              text: `Kicked by ${interaction.user.username} | ${originalembed?.footer?.text || userid}`,
-            });
-
-          await logChannel.send({ content: `<@${userid}>`, embeds: [Embed] });
-          await message.delete().catch(console.error);
-        }
-      }
+  // Process log messages
+  try {
+    await processLogMessages({
+      interaction,
+      client,
+      application,
+      messageids,
+      user: member,
+      status: VerificationStatus.KICKED,
+      useRateLimiting: false,
+    });
+  } catch (logError) {
+    if (logError.code === 50001 || logError.code === 50013) {
+      console.warn(`Missing permissions for log messages in guild ${interaction.guild.id}`);
+      await interaction.followUp({
+        content: "Warning: Could not process log messages due to missing permissions.",
+        flags: MessageFlags.Ephemeral,
+      }).catch(() => {});
+    } else {
+      throw logError;
     }
-  } else {
+  }
+
+  // If no separate log channel, edit the current message
+  if (!application?.verifylogs || application.reviewchannel === application.verifylogs) {
     if (interaction.message.flags.has(MessageFlags.IsComponentsV2)) {
-      const verifiedContainer = await handleV2edit(
-        interaction,
-        interaction.message,
+      const { container, files } = relinkAttachments(interaction.message);
+
+      const tempMsg = { ...interaction.message, components: [container] };
+      const kickedContainer = handleV2Edit(
+        interaction, 
+        tempMsg, 
+        VerificationStatus.KICKED
       );
 
-      await interaction.editReply({
+      const editPayload = {
         flags: [MessageFlags.IsComponentsV2],
-        components: [verifiedContainer],
-      });
+        components: [kickedContainer],
+      };
+      if (files) editPayload.files = files;
+      await interaction.editReply(editPayload);
 
       if (interaction.message.thread) {
         await interaction.message.thread.setArchived(true);
       }
-    } else {
-      const originalEmbed = interaction.message.embeds[0];
-      let fields = originalEmbed.fields || [];
-
-      // Remove confirmation field
-      if (
-        fields.length > 0 &&
-        fields[fields.length - 1].name.includes("Are you sure")
-      ) {
-        fields.pop();
-      }
-
-      const embed = new EmbedBuilder(originalEmbed)
-        .setColor("#EB2121")
-        .setTitle(originalEmbed.title + " (KICKED)")
-        .setFields(fields)
-        .setFooter({
-          text: `Kicked by ${interaction.user.username} | ${originalEmbed?.footer?.text || userid}`,
-        });
-
-      await interaction.editReply({ embeds: [embed], components: [] });
-    }
-
-    if (messageids && messageids.length > 0) {
-      for (const messageId of messageids) {
-        if (messageId === interaction.message.id) {
-          continue;
-        }
-
-        try {
-          const message = await interaction.channel.messages.fetch(messageId);
-          // 1 second delay
-          await new Promise((resolve) => setTimeout(resolve, 1000));
-
-          if (message && message.author.id === client.user.id) {
-            if (message.flags.has(MessageFlags.IsComponentsV2)) {
-              const editedContainer = await handleV2edit(interaction, message);
-              await message.edit({
-                flags: [MessageFlags.IsComponentsV2],
-                components: [editedContainer],
-              });
-            } else if (!message?.embeds[0]?.footer?.text?.includes("Kicked")) {
-              const originalembed = message.embeds[0];
-
-              let Embed = new EmbedBuilder(originalembed)
-                .setColor("#EB2121")
-                .setTitle(originalembed.title + " (KICKED)")
-                .setFooter({
-                  text: `Kicked by ${interaction.user.username} | ${originalembed?.footer?.text || userid}`,
-                });
-
-              await message.edit({ embeds: [Embed], components: [] });
-            }
-          }
-        } catch (error) {
-          console.error(
-            `Failed to process message with ID ${messageId}: ${error}`,
-          );
-        }
-      }
     }
   }
 
-  //delete the message ids from verification table
   if (messageids && messageids.length > 0) {
-    delete verification.guildVerifications[interaction.guild.id];
-    verification.changed("guildVerifications", true);
-    await verification.save();
+    await cleanupVerificationData(verification, interaction.guild.id);
   }
 };
-
-async function handleV2edit(interaction, message) {
-  const editedContainer = new ContainerBuilder({
-    accent_color: 0xeb2121,
-  });
-
-  const originalContainer = message.components[0];
-
-  if (originalContainer?.components) {
-    for (const component of originalContainer.components) {
-      if (component.type === 9) {
-        let content = component.components[0].content;
-
-        content = content.replace(/<@&\d+>/g, "").trim();
-
-        editedContainer.addSectionComponents(
-          new SectionBuilder()
-            .addTextDisplayComponents(
-              new TextDisplayBuilder({
-                content:
-                  content +
-                  `\n**Status:** \`Kicked by ${interaction.user.username}\``,
-              }),
-            )
-            .setThumbnailAccessory(
-              new ThumbnailBuilder({
-                media: { url: component.accessory.media.url },
-              }),
-            ),
-        );
-      }
-      if (component.type === 10) {
-        editedContainer.addTextDisplayComponents(
-          new TextDisplayBuilder({
-            content: component.content,
-          }),
-        );
-      } else if (component.type === 14) {
-        editedContainer.addSeparatorComponents(
-          new SeparatorBuilder({
-            spacing: component.spacing || SeparatorSpacingSize.Small,
-          }),
-        );
-      } else if (component.type === 12) {
-        if (component.items?.length > 0) {
-          const mappedurls = component.items?.map((item) => ({
-            media: {
-              url: item.media.url,
-            },
-          }));
-          editedContainer.addMediaGalleryComponents(
-            new MediaGalleryBuilder({
-              items: mappedurls,
-            }),
-          );
-        }
-      }
-    }
-  }
-
-  editedContainer.addTextDisplayComponents(
-    new TextDisplayBuilder({
-      content: `-# Kicked by ${interaction.user.username} (${interaction.user.id})`,
-    }),
-  );
-
-  return editedContainer;
-}

--- a/button_commands/deny.js
+++ b/button_commands/deny.js
@@ -1,10 +1,10 @@
 const {
   ButtonBuilder,
   ActionRowBuilder,
-  EmbedBuilder,
   MessageFlags,
 } = require("discord.js");
 const { getApplicationByIdWithFallback } = require("../js/tempconfigfuncs.js");
+const { relinkAttachments } = require("../js/verificationHandler.js");
 
 module.exports = async ({ interaction, applicationId }) => {
   await interaction.deferUpdate();
@@ -64,19 +64,12 @@ module.exports = async ({ interaction, applicationId }) => {
   );
 
   if (hasComponents) {
-    await interaction.message.edit({
+    const { container, files } = relinkAttachments(interaction.message);
+    const editPayload = {
       flags: [MessageFlags.IsComponentsV2],
-      components: [originalComponents[0], verifyRow],
-    });
-  } else {
-    const verifyEmbed = new EmbedBuilder(originalEmbed).addFields({
-      name: "Are you sure you want to deny this user?",
-      value: 'Click "Confirm Verification" to deny or "Cancel" to return.',
-    });
-
-    await interaction.message.edit({
-      embeds: [verifyEmbed],
-      components: [verifyRow],
-    });
+      components: [container, verifyRow],
+    };
+    if (files) editPayload.files = files;
+    await interaction.message.edit(editPayload);
   }
 };

--- a/button_commands/denyconfirm.js
+++ b/button_commands/denyconfirm.js
@@ -1,9 +1,10 @@
-const { MessageFlags, EmbedBuilder } = require("discord.js");
+const { MessageFlags } = require("discord.js");
 const { Verification } = require("../dbObjects.js");
 const {
   checkManagerPermission,
   handleV2Edit,
   VerificationStatus,
+  relinkAttachments,
   processLogMessages,
   cleanupVerificationData,
   sendDenyDM,
@@ -59,45 +60,50 @@ module.exports = async ({ interaction, client, userid, context, applicationId })
   }
 
   // Process log messages
-  await processLogMessages({
-    interaction,
-    client,
-    application,
-    messageids,
-    user: member,
-    status: VerificationStatus.DENIED,
-    useRateLimiting: false,
-  });
+  try {
+    await processLogMessages({
+      interaction,
+      client,
+      application,
+      messageids,
+      user: member,
+      status: VerificationStatus.DENIED,
+      useRateLimiting: false,
+    });
+  } catch (logError) {
+    if (logError.code === 50001 || logError.code === 50013) {
+      console.warn(`Missing permissions for log messages in guild ${interaction.guild.id}`);
+      await interaction.followUp({
+        content: "Warning: Could not process log messages due to missing permissions.",
+        flags: MessageFlags.Ephemeral,
+      }).catch(() => {});
+    } else {
+      throw logError;
+    }
+  }
 
   // If no separate log channel, edit the current message
   if (!application.verifylogs || application.reviewchannel === application.verifylogs) {
     if (interaction.message.flags.has(MessageFlags.IsComponentsV2)) {
-      const deniedContainer = handleV2Edit(interaction, interaction.message, VerificationStatus.DENIED);
-      await interaction.editReply({
+      const { container, files } = relinkAttachments(interaction.message);
+
+      const tempMsg = { ...interaction.message, components: [container] };
+      const deniedContainer = handleV2Edit(
+        interaction, 
+        tempMsg, 
+        VerificationStatus.DENIED
+      );
+
+      const editPayload = {
         flags: [MessageFlags.IsComponentsV2],
         components: [deniedContainer],
-      });
+      };
+      if (files) editPayload.files = files;
+      await interaction.editReply(editPayload);
 
       if (interaction.message.thread) {
         await interaction.message.thread.setArchived(true);
       }
-    } else {
-      const originalEmbed = interaction.message.embeds[0];
-      let fields = originalEmbed.fields || [];
-
-      if (fields.length > 0 && fields[fields.length - 1].name.includes("Are you sure")) {
-        fields.pop();
-      }
-
-      const embed = new EmbedBuilder(originalEmbed)
-        .setColor("#EB2121")
-        .setTitle(originalEmbed.title + " (DENIED)")
-        .setFields(fields)
-        .setFooter({
-          text: `Denied by ${interaction.user.username} | ${originalEmbed?.footer?.text || userid}`,
-        });
-
-      await interaction.editReply({ embeds: [embed], components: [] });
     }
   }
 

--- a/button_commands/returntomenu.js
+++ b/button_commands/returntomenu.js
@@ -1,10 +1,10 @@
 const {
   ButtonBuilder,
   ActionRowBuilder,
-  EmbedBuilder,
   MessageFlags,
 } = require("discord.js");
 const { getApplicationById } = require("../js/tempconfigfuncs.js");
+const { relinkAttachments } = require("../js/verificationHandler.js");
 
 module.exports = async ({ interaction, applicationId }) => {
   const verify = new ActionRowBuilder().addComponents(
@@ -51,18 +51,9 @@ module.exports = async ({ interaction, applicationId }) => {
   }
 
   if (interaction.message.flags.has(MessageFlags.IsComponentsV2)) {
-    const originalComponents = interaction.message.components;
-
-    const firstcomponent = originalComponents.shift();
-
-    await interaction.update({ components: [firstcomponent, verify] });
-  } else {
-    //remove last field from embed
-    const originalembed = interaction.message.embeds[0];
-    const verifiedEmbed = new EmbedBuilder(originalembed)
-      .spliceFields(-1, 1)
-      .setColor("#3f7ff1");
-
-    await interaction.update({ embeds: [verifiedEmbed], components: [verify] });
+    const { container, files } = relinkAttachments(interaction.message);
+    const editPayload = { components: [container, verify] };
+    if (files) editPayload.files = files;
+    await interaction.update(editPayload);
   }
 };

--- a/button_commands/verify.js
+++ b/button_commands/verify.js
@@ -1,10 +1,10 @@
 const {
   ButtonBuilder,
   ActionRowBuilder,
-  EmbedBuilder,
   MessageFlags,
 } = require("discord.js");
 const { getApplicationById } = require("../js/tempconfigfuncs.js");
+const { relinkAttachments } = require("../js/verificationHandler.js");
 
 module.exports = async ({ interaction, applicationId }) => {
   await interaction.deferUpdate();
@@ -60,7 +60,7 @@ module.exports = async ({ interaction, applicationId }) => {
   const verifyRow = new ActionRowBuilder().addComponents(
     new ButtonBuilder()
       .setCustomId(`verifyconfirm_${applicationId}_${interaction.user.id}`)
-      .setLabel("Confirm Verification")
+      .setLabel("Confirm Accept")
       .setStyle("Success"),
     new ButtonBuilder()
       .setCustomId(`returntomenu_${applicationId}`)
@@ -69,19 +69,12 @@ module.exports = async ({ interaction, applicationId }) => {
   );
 
   if (hasComponents) {
-    await interaction.message.edit({
+    const { container, files } = relinkAttachments(interaction.message);
+    const editPayload = {
       flags: [MessageFlags.IsComponentsV2],
-      components: [originalComponents[0], verifyRow],
-    });
-  } else {
-    const verifyEmbed = new EmbedBuilder(originalEmbed).addFields({
-      name: "Are you sure you want to verify this user?",
-      value: 'Click "Confirm Verification" to verify or "Cancel" to return.',
-    });
-
-    await interaction.message.edit({
-      embeds: [verifyEmbed],
-      components: [verifyRow],
-    });
+      components: [container, verifyRow],
+    };
+    if (files) editPayload.files = files;
+    await interaction.message.edit(editPayload);
   }
 };

--- a/button_commands/verifybutton.js
+++ b/button_commands/verifybutton.js
@@ -15,6 +15,8 @@ const {
   MediaGalleryBuilder,
   ThumbnailBuilder,
   SectionBuilder,
+  AttachmentBuilder,
+  FileBuilder,
 } = require("discord.js");
 const { v4: uuidv4 } = require("uuid");
 const { updateVerifications, getApplicationByIdWithFallback } = require("../js/tempconfigfuncs.js");
@@ -169,7 +171,6 @@ module.exports = async ({ interaction, client, applicationId }) => {
     }
 
     const botMember = interaction.guild.members.me ?? await interaction.guild.members.fetchMe();
-  
     const botPermissions = verifyLogsChannel.permissionsFor(botMember);
     if (
       !botPermissions ||
@@ -882,9 +883,10 @@ module.exports = async ({ interaction, client, applicationId }) => {
     }
   } catch (error) {
     console.error("Verification error:", error);
-    await interaction.editReply({
-      content: `An error occurred during the verification process. Please try again later.`,
-      flags: MessageFlags.Ephemeral,
+    // throw error;
+
+    await interaction.user.send({
+      content: `An error occurred during the verification process! Please try again later or contact the server staff/[Melpo's Support server](https://discord.gg/jjGAwwwxZz). (${error.message})`,
     });
   } finally {
     activeVerifications.delete(interaction.user.id);
@@ -931,15 +933,32 @@ async function constructApplicationEmbed(
 
   if (answers.length > 0) {
     let totalCharacterCount = 0;
+    let absoluteTotalCharacterCount = 0;
     const MAX_TOTAL_CHARACTERS = 3600;
     const MAX_FIELD_CHARACTERS = 1024;
+    let wasTruncated = false;
+    const fullTextLines = [];
+
     answers.forEach((answer, index) => {
+      absoluteTotalCharacterCount += questions[index].content.length + (answer.content?.length || 0);
+    });
+
+    answers.forEach((answer, index) => {
+      const questioncontent = questions[index].content.replace(/(\*\*|__|\*|~~|`|>)/g, "");
+      const rawContent = answer.content || "No answer provided";
+      fullTextLines.push(`Q${index + 1}: ${questioncontent}`);
+      fullTextLines.push(`Answer: ${rawContent}`);
+      if (answer.attachments && answer.attachments.length > 0) {
+        fullTextLines.push(`Attachments: ${answer.attachments.join(', ')}`);
+      }
+      fullTextLines.push('');
 
       if(totalCharacterCount >= MAX_TOTAL_CHARACTERS) {
+        wasTruncated = true;
         return;
       }
 
-      const questionText = `**${index + 1}.** **${questions[index].content}**`;
+      const questionText = absoluteTotalCharacterCount >= MAX_TOTAL_CHARACTERS ? `**${index + 1}.** **${questioncontent.slice(0, 10)}...**` : `**${index + 1}.** **${questioncontent}**`;
       const answertext = answer.content || "No answer provided";
 
       let formattedField = [
@@ -949,23 +968,18 @@ async function constructApplicationEmbed(
 
       if (formattedField.length > MAX_FIELD_CHARACTERS) {
         formattedField = formattedField.slice(0, MAX_FIELD_CHARACTERS - 3) + "...";
+        wasTruncated = true;
       }
 
       if (totalCharacterCount + formattedField.length > MAX_TOTAL_CHARACTERS) {
         const remainingCharacters = MAX_TOTAL_CHARACTERS - totalCharacterCount;
         if (remainingCharacters > 100) { // Only add if there's meaningful space left
           formattedField = formattedField.slice(0, remainingCharacters - 3) + "...";
+          wasTruncated = true;
           console.log(`Truncated field ${index + 1} to fit within total limits.`);
         } else {
+          wasTruncated = true;
           console.log(`Field ${index + 1} exceeds total limit and will not be added.`);
-          // Add a note that content was truncated
-          if (totalCharacterCount + 60 <= MAX_TOTAL_CHARACTERS) { // Check if we can fit the truncation notice
-            container.addTextDisplayComponents(
-              new TextDisplayBuilder({
-                content: "**Note:** Some responses were truncated due to length limits.",
-              }),
-            );
-          }
           return;
         }
       }
@@ -992,9 +1006,34 @@ async function constructApplicationEmbed(
         );
       }
     });
+
+    const fullText = wasTruncated ? fullTextLines.join('\n') : null
+
+    if (wasTruncated && fullText) {
+      const safeAppName = appName.replace(/[^a-zA-Z0-9_-]/g, '_');
+      const name = `${user.id}_${safeAppName}.txt`;
+      const buffer = Buffer.from(fullText, 'utf-8');
+      const attachment = new AttachmentBuilder(buffer, { name });
+      container.addFileComponents(
+        new FileBuilder().setURL(`attachment://${name}`),
+      );
+
+      return {
+        container,
+        wasTruncated,
+        fullText,
+        attachment,
+      };
+    }
+
+    return {
+      container,
+      wasTruncated,
+      fullText: fullText
+    };
   }
 
-  return container;
+  return { container, wasTruncated: false, fullText: null };
 }
 
 async function processVerificationResult(
@@ -1045,7 +1084,7 @@ async function processVerificationResult(
 
     user = user || interaction.user;
 
-    const container = await constructApplicationEmbed(
+    const { container, attachment } = await constructApplicationEmbed(
       user,
       botQuestions,
       responses,
@@ -1081,10 +1120,16 @@ async function processVerificationResult(
 
     let channelsent;
 
-    channelsent = await verifyLogsChannel.send({
+    const sendPayload = {
       flags: [MessageFlags.IsComponentsV2],
       components: [container, verify],
-    });
+    };
+
+    if (attachment) {
+      sendPayload.files = [attachment];
+    }
+
+    channelsent = await verifyLogsChannel.send(sendPayload);
     if (useThreads === true) {
       await channelsent.startThread({
         name: `${user.globalName ?? user.username}'s Verification`,

--- a/button_commands/verifyconfirm.js
+++ b/button_commands/verifyconfirm.js
@@ -1,10 +1,11 @@
-const { MessageFlags, EmbedBuilder } = require("discord.js");
+const { MessageFlags } = require("discord.js");
 const { Verification } = require("../dbObjects.js");
 const {
   checkManagerPermission,
   validateRoles,
   handleV2Edit,
   VerificationStatus,
+  relinkAttachments,
   processLogMessages,
   cleanupVerificationData,
   sendWelcomeMessage,
@@ -80,7 +81,15 @@ module.exports = async ({ interaction, client, userid, context, applicationId })
   const originalEmbed = interaction.message.embeds[0];
 
   // Apply roles
-  await applyRoles(user, verifiedRoles, unverifiedRoles);
+  const botMember = interaction.guild.members.me;
+  if (!botMember || !botMember.permissions.has("ManageRoles")) {
+    return await interaction.followUp({
+      content: "I don't have the **Manage Roles** permission. Please grant it and try again.",
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  await applyRoles(user, verifiedRoles, unverifiedRoles, interaction);
 
   // Send welcome message
   if (welcomeChannel && welcomeMessage) {
@@ -119,32 +128,25 @@ module.exports = async ({ interaction, client, userid, context, applicationId })
   // If no separate log channel, edit the current message
   if (!application.verifylogs || application.reviewchannel === application.verifylogs) {
     if (interaction.message.flags.has(MessageFlags.IsComponentsV2)) {
-      const verifiedContainer = handleV2Edit(interaction, interaction.message, VerificationStatus.VERIFIED);
-      await interaction.editReply({
+      const { container, files } = relinkAttachments(interaction.message);
+
+      const tempMsg = { ...interaction.message, components: [container] };
+      const verifiedContainer = handleV2Edit(
+        interaction,
+        tempMsg,
+        VerificationStatus.VERIFIED,
+      );
+
+      const editPayload = {
         flags: [MessageFlags.IsComponentsV2],
         components: [verifiedContainer],
-      });
+      };
+      if (files) editPayload.files = files;
+      await interaction.editReply(editPayload);
 
       if (interaction.message.thread) {
         await interaction.message.thread.setArchived(true);
       }
-    } else {
-      const originalEmbedData = interaction.message.embeds[0];
-      let fields = originalEmbedData.fields || [];
-
-      if (fields.length > 0 && fields[fields.length - 1].name.includes("Are you sure")) {
-        fields.pop();
-      }
-
-      const embed = new EmbedBuilder(originalEmbedData)
-        .setColor("#008000")
-        .setTitle(originalEmbedData.title + " (VERIFIED)")
-        .setFields(fields)
-        .setFooter({
-          text: `Verified by ${interaction.user.username} | ${originalEmbedData?.footer?.text || userid}`,
-        });
-
-      await interaction.editReply({ embeds: [embed], components: [] });
     }
   }
 

--- a/commands/utility/verify.js
+++ b/commands/utility/verify.js
@@ -174,7 +174,7 @@ module.exports = {
         if (!user) throw new Error("User not found");
 
         // Apply roles
-        await applyRoles(user, verifiedRoles, unverifiedRoles);
+        await applyRoles(user, verifiedRoles, unverifiedRoles, interaction);
 
         results.success.push(userID);
 

--- a/js/verificationHandler.js
+++ b/js/verificationHandler.js
@@ -8,6 +8,9 @@ const {
   MediaGalleryBuilder,
   SectionBuilder,
   ThumbnailBuilder,
+  PermissionsBitField,
+  FileBuilder,
+  AttachmentBuilder,
 } = require("discord.js");
 const { Verification, InviteTracker } = require("../dbObjects.js");
 const { resolveImage } = require("./imageUtils.js");
@@ -15,11 +18,13 @@ const { resolveImage } = require("./imageUtils.js");
 const VerificationStatus = {
   VERIFIED: "verified",
   DENIED: "denied",
+  KICKED: "kicked",
 };
 
 const StatusColors = {
   [VerificationStatus.VERIFIED]: 0x008000,
   [VerificationStatus.DENIED]: 0xeb2121,
+  [VerificationStatus.KICKED]: 0xeb2121,
 };
 
 async function rateLimitedOperation(operation, maxRetries = 3) {
@@ -95,7 +100,7 @@ async function validateRoles(interaction, verifiedRoles, unverifiedRoles) {
 
   if (verifiedRoles && verifiedRoles.length > 0) {
     for (const roleId of verifiedRoles) {
-      const role = await interaction.guild.roles.fetch(roleId);
+      const role = await interaction.guild.roles.fetch(roleId).catch(() => null);
       if (!role) {
         errors.push(`Verified role with ID ${roleId} not found. Please update your server configuration.`);
         continue;
@@ -110,7 +115,7 @@ async function validateRoles(interaction, verifiedRoles, unverifiedRoles) {
 
   if (unverifiedRoles && unverifiedRoles.length > 0) {
     for (const roleId of unverifiedRoles) {
-      const role = await interaction.guild.roles.fetch(roleId);
+      const role = await interaction.guild.roles.fetch(roleId).catch(() => null);
       if (role && interaction.guild.members.me.roles.highest.comparePositionTo(role) <= 0) {
         errors.push(`Cannot remove role ${role.name} because it's higher than or equal to my highest role.`);
       }
@@ -121,42 +126,77 @@ async function validateRoles(interaction, verifiedRoles, unverifiedRoles) {
 }
 
 // Apply roles to user (add verified, remove unverified)
-async function applyRoles(user, verifiedRoles, unverifiedRoles) {
+async function applyRoles(user, verifiedRoles, unverifiedRoles, interaction) {
   if (unverifiedRoles && unverifiedRoles.length > 0) {
     for (const roleId of unverifiedRoles) {
-      await user.roles.remove(roleId).catch(console.error);
+      await user.roles.remove(roleId).catch(
+        (err) => {
+          if (err.code === 10011) {
+            interaction.channel.send(`Unknown role ${roleId} during removal, skipping. Please reconfigure your roles in setup.`).catch(() => {});
+          } else {
+            console.error(`Failed to remove role ${roleId}: ${err.message}`);
+          }
+        }
+      );
     }
   }
 
   if (verifiedRoles && verifiedRoles.length > 0) {
     for (const roleId of verifiedRoles) {
-      await user.roles.add(roleId).catch(console.error);
+      await user.roles.add(roleId).catch(
+        (err) => {
+          if (err.code === 10011) {
+            interaction.channel.send(`Unknown role ${roleId} during addition, skipping. Please reconfigure your roles in setup.`).catch(() => {});
+          } else {
+            console.error(`Failed to add role ${roleId}: ${err.message}`);
+          }
+        }
+      );
     }
   }
 }
 
-// Handle V2 container edit for verification/denial
-function handleV2Edit(interaction, message, status) {
+function handleV2Edit(interaction, message, status, reason = null) {
+  const MAX_DISPLAYABLE_TEXT = 4000;
   const color = StatusColors[status];
-  const statusText = status === VerificationStatus.VERIFIED ? "Verified" : "Denied";
+  const statusTextMap = {
+    [VerificationStatus.VERIFIED]: "Verified",
+    [VerificationStatus.DENIED]: "Denied",
+    [VerificationStatus.KICKED]: "Kicked",
+  };
+  const statusText = statusTextMap[status] || "Denied";
 
+  const footerText = `-# ${statusText} by ${interaction.user.username} (${interaction.user.id})`;
+  const statusSuffix = reason
+    ? `\n**Status:** \`${statusText} by ${interaction.user.username}\`: ${reason}`
+    : `\n**Status:** \`${statusText} by ${interaction.user.username}\``;
+  const reservedChars = footerText.length + 50;
+  let totalTextLength = 0;
+
+  const clonedContainer = JSON.parse(JSON.stringify(message.components[0] || {}));
   const editedContainer = new ContainerBuilder({
     accent_color: color,
   });
 
-  const originalContainer = message.components[0];
-
-  if (originalContainer?.components) {
-    for (const component of originalContainer.components) {
+  if (clonedContainer.components) {
+    for (const component of clonedContainer.components) {
       if (component.type === 9) {
         let content = component.components[0].content;
         content = content.replace(/<@&\d+>/g, "").trim();
+
+        const fullContent = content + statusSuffix;
+        const available = MAX_DISPLAYABLE_TEXT - totalTextLength - reservedChars;
+        const truncatedContent = available < fullContent.length
+          ? fullContent.slice(0, Math.max(available - 3, 0)) + "..."
+          : fullContent;
+
+        totalTextLength += truncatedContent.length;
 
         editedContainer.addSectionComponents(
           new SectionBuilder()
             .addTextDisplayComponents(
               new TextDisplayBuilder({
-                content: content + `\n**Status:** \`${statusText} by ${interaction.user.username}\``,
+                content: truncatedContent,
               }),
             )
             .setThumbnailAccessory(
@@ -166,9 +206,18 @@ function handleV2Edit(interaction, message, status) {
             ),
         );
       } else if (component.type === 10) {
+        const available = MAX_DISPLAYABLE_TEXT - totalTextLength - reservedChars;
+        if (available <= 0) continue;
+
+        const content = available < component.content.length
+          ? component.content.slice(0, Math.max(available - 3, 0)) + "..."
+          : component.content;
+
+        totalTextLength += content.length;
+
         editedContainer.addTextDisplayComponents(
           new TextDisplayBuilder({
-            content: component.content,
+            content: content,
           }),
         );
       } else if (component.type === 14) {
@@ -188,13 +237,19 @@ function handleV2Edit(interaction, message, status) {
             }),
           );
         }
+      } else if (component.type === 13) {
+        if (component.file?.url?.startsWith('attachment://')) {
+          editedContainer.addFileComponents(
+            new FileBuilder().setURL(component.file.url),
+          );
+        }
       }
     }
   }
 
   editedContainer.addTextDisplayComponents(
     new TextDisplayBuilder({
-      content: `-# ${statusText} by ${interaction.user.username} (${interaction.user.id})`,
+      content: footerText,
     }),
   );
 
@@ -435,10 +490,22 @@ async function processLogMessages(options) {
     messageids,
     user,
     status,
+    reason = null,
     useRateLimiting = false,
   } = options;
 
-  const statusText = status === VerificationStatus.VERIFIED ? "VERIFIED" : "DENIED";
+  const statusTextMap = {
+    [VerificationStatus.VERIFIED]: "VERIFIED",
+    [VerificationStatus.DENIED]: "DENIED",
+    [VerificationStatus.KICKED]: "KICKED",
+  };
+  const actionTextMap = {
+    [VerificationStatus.VERIFIED]: "Verified",
+    [VerificationStatus.DENIED]: "Denied",
+    [VerificationStatus.KICKED]: "Kicked",
+  };
+  const statusText = statusTextMap[status] || "DENIED";
+  const actionText = actionTextMap[status] || "Denied";
   const color = StatusColors[status];
 
   const hasSeparateLogChannel =
@@ -451,6 +518,20 @@ async function processLogMessages(options) {
     const logChannel = interaction.guild.channels.cache.get(application.verifylogs);
 
     if (logChannel && reviewChannel && messageids && messageids.length > 0) {
+      const botMember = interaction.guild.members.me ?? await logChannel.guild.members.fetchMe();
+      const botPermissions = logChannel.permissionsFor(botMember);
+      if (
+        !botPermissions ||
+        !botPermissions.has([
+          PermissionsBitField.Flags.SendMessages,
+          PermissionsBitField.Flags.ViewChannel,
+        ])
+      ) {
+        return await interaction.channel.send({
+          content: `<@${user.id}>, I don't have permissions to send messages in the verification review channel!`,
+        });
+      }
+
       const messages = [];
       for (const messageId of messageids) {
         try {
@@ -476,18 +557,25 @@ async function processLogMessages(options) {
 
         try {
           if (message.flags?.has(MessageFlags.IsComponentsV2)) {
-            const editedContainer = handleV2Edit(interaction, message, status);
+            const { container: preparedContainer, files } = relinkAttachments(message);
+            const tempMsg = { ...message, components: [preparedContainer] };
+            const editedContainer = handleV2Edit(interaction, tempMsg, status, reason);
 
             let threadEmbed;
             if (message.thread) {
               threadEmbed = await createThreadSummary(message.thread, client, status);
             }
 
-            const sendOp = async () =>
-              logChannel.send({
+            const sendOp = async () => {
+              const payload = {
                 flags: [MessageFlags.IsComponentsV2],
                 components: [editedContainer],
-              });
+              };
+              if (files) {
+                payload.files = files;
+              }
+              return logChannel.send(payload);
+            };
 
             const sendmessage = useRateLimiting
               ? await rateLimitedOperation(sendOp)
@@ -520,26 +608,6 @@ async function processLogMessages(options) {
 
             const deleteOp = async () => message.delete();
             (useRateLimiting ? rateLimitedOperation(deleteOp) : deleteOp()).catch(console.error);
-          } else if (message.embeds && message.embeds[0]) {
-            const originalembed = message.embeds[0];
-
-            const Embed = new EmbedBuilder(originalembed)
-              .setColor(color)
-              .setTitle((originalembed.title || "Verification") + ` (${statusText})`)
-              .setFooter({
-                text: `${statusText === "VERIFIED" ? "Verified" : "Denied"} by ${interaction.user.username} | ${originalembed?.footer?.text || user.id}`,
-              });
-
-            const logOp = async () =>
-              logChannel.send({
-                content: `<@${user.id}>`,
-                embeds: [Embed],
-              });
-
-            useRateLimiting ? await rateLimitedOperation(logOp) : await logOp();
-
-            const delOp = async () => message.delete();
-            (useRateLimiting ? rateLimitedOperation(delOp) : delOp()).catch(console.error);
           }
         } catch (error) {
           console.error("Error processing log message:", error);
@@ -563,11 +631,11 @@ async function processLogMessages(options) {
           if (message && message.author.id === client.user.id) {
             const footerText = message.embeds?.[0]?.footer?.text || "";
             const alreadyProcessed =
-              footerText.includes("Verified") || footerText.includes("Denied");
+              footerText.includes("Verified") || footerText.includes("Denied") || footerText.includes("Kicked");
 
             if (!alreadyProcessed) {
               if (message.flags?.has(MessageFlags.IsComponentsV2)) {
-                const editedContainer = handleV2Edit(interaction, message, status);
+                const editedContainer = handleV2Edit(interaction, message, status, reason);
                 const editOp = async () =>
                   message.edit({
                     flags: [MessageFlags.IsComponentsV2],
@@ -581,8 +649,12 @@ async function processLogMessages(options) {
                   .setColor(color)
                   .setTitle((originalembed.title || "Verification") + ` (${statusText})`)
                   .setFooter({
-                    text: `${statusText === "VERIFIED" ? "Verified" : "Denied"} by ${interaction.user.username} | ${originalembed?.footer?.text || user.id}`,
+                    text: `${actionText} by ${interaction.user.username} | ${originalembed?.footer?.text || user.id}`,
                   });
+
+                if (reason) {
+                  Embed.setDescription(`**Denied for reason:** ${reason}`);
+                }
 
                 const editOp = async () => message.edit({ embeds: [Embed], components: [] });
                 useRateLimiting ? await rateLimitedOperation(editOp) : await editOp();
@@ -649,7 +721,7 @@ async function verifyUser(options) {
   const welcomeChannel = application.verificationwelcomechannel;
 
   // Apply roles
-  await applyRoles(user, verifiedRoles, unverifiedRoles);
+  await applyRoles(user, verifiedRoles, unverifiedRoles, interaction);
 
   // Get verification data
   const verification = await Verification.findOne({ where: { userId } });
@@ -768,6 +840,30 @@ async function denyUser(options) {
   return { success: true, user, dmDisabled: dmResult.dmDisabled };
 }
 
+function relinkAttachments(message) {
+  const container = JSON.parse(JSON.stringify(message.components?.[0] || {}));
+  const comps = container.components || [];
+
+  const fileComp = comps[comps.length - 1];
+  if (!fileComp?.file?.url) {
+    return { container, files: null };
+  }
+
+  const url = fileComp.file.url;
+  const name =
+    fileComp.file.name || url.split('/').pop().split('?')[0];
+
+  if (!url.startsWith('attachment://')) {
+    fileComp.file.url = `attachment://${name}`;
+    return {
+      container,
+      files: [new AttachmentBuilder(url, { name })],
+    };
+  }
+
+  return { container, files: null };
+}
+
 module.exports = {
   VerificationStatus,
   StatusColors,
@@ -777,6 +873,7 @@ module.exports = {
   validateRoles,
   applyRoles,
   handleV2Edit,
+  relinkAttachments,
   processText,
   getMentions,
   sendWelcomeMessage,

--- a/modal_commands/denyModal.js
+++ b/modal_commands/denyModal.js
@@ -1,15 +1,13 @@
-const {
-  EmbedBuilder,
-  MessageFlags,
-  ContainerBuilder,
-  TextDisplayBuilder,
-  SeparatorBuilder,
-  SeparatorSpacingSize,
-  MediaGalleryBuilder,
-  SectionBuilder,
-  ThumbnailBuilder,
-} = require("discord.js");
+const { MessageFlags } = require("discord.js");
 const { Verification } = require("../dbObjects.js");
+const {
+  handleV2Edit,
+  VerificationStatus,
+  relinkAttachments,
+  processLogMessages,
+  cleanupVerificationData,
+  sendDenyDM,
+} = require("../js/verificationHandler.js");
 const { getApplicationByIdWithFallback } = require("../js/tempconfigfuncs.js");
 
 module.exports = async ({ interaction, client, userid, applicationId }) => {
@@ -38,312 +36,80 @@ module.exports = async ({ interaction, client, userid, applicationId }) => {
   const messageids = verification?.guildVerifications?.[interaction.guild.id];
   const reason = interaction.fields.getTextInputValue("denyInput");
 
-  if (
-    application.verifylogs &&
-    messageids &&
-    application.reviewchannel !== application.verifylogs
-  ) {
-    const reviewChannel = interaction.guild.channels.cache.get(
-      application.reviewchannel,
-    );
-    const logChannel = interaction.guild.channels.cache.get(
-      application.verifylogs,
-    );
+  let member;
+  try {
+    member = await interaction.guild.members.fetch(userid);
+  } catch {
+    member = { user, id: userid };
+  }
 
-    if (logChannel && reviewChannel && messageids) {
-      const messages = [];
-      for (const messageId of messageids) {
-        try {
-          const message = await reviewChannel.messages.fetch(messageId);
-          if (message) messages.push(message);
-          await new Promise((resolve) => setTimeout(resolve, 300));
-        } catch (error) {
-          if (error.code === 10008) {
-            console.log(`Message ${messageId} not found - skipping`);
-            continue;
-          }
-          throw error;
-        }
-      }
-
-      // Sort by timestamp
-      messages.sort((a, b) => a.createdTimestamp - b.createdTimestamp);
-
-      for (const message of messages) {
-        await new Promise((resolve) => setTimeout(resolve, 600));
-
-        if (message.flags.has(MessageFlags.IsComponentsV2)) {
-          const verifiedContainer = await handleV2edit(
-            interaction,
-            message,
-            reason,
-          );
-
-          let threadEmbed;
-
-          if (message.thread) {
-            threadEmbed = new EmbedBuilder()
-              .setTitle(`Thread Summary`)
-              .setColor("#EB2121");
-
-            try {
-              const threadMessages = await message.thread.messages.fetch();
-
-              if (threadMessages.size > 1) {
-                const messagesArray = Array.from(threadMessages.values())
-                  .sort((a, b) => a.createdTimestamp - b.createdTimestamp)
-                  .slice(1);
-
-                const formattedMessages = messagesArray?.map((msg) => {
-                  let content;
-
-                  if (msg.flags.has(MessageFlags.IsComponentsV2)) {
-                    content =
-                      msg.components?.[0]?.components?.[0]?.content ||
-                      "No content";
-                  } else {
-                    content = msg.content || "No content";
-                  }
-
-                  if (msg.author.id === client.user.id) {
-                    content = content?.replace(
-                      /### Question answered by[^\n]*\n?/g,
-                      "\n",
-                    );
-                  }
-
-                  return `\`${msg.author.username}:\` ${content}`;
-                });
-
-                const finalContent = formattedMessages
-                  .join("\n")
-                  .slice(0, 4096);
-                threadEmbed.setDescription(
-                  finalContent || "No messages in thread",
-                );
-              } else {
-                threadEmbed.setDescription("No additional messages in thread");
-              }
-            } catch (error) {
-              console.error("Error fetching thread messages:", error);
-              threadEmbed.setDescription("Error loading thread messages");
-            }
-          }
-
-          let sendmessage = await logChannel.send({
-            flags: [MessageFlags.IsComponentsV2],
-            components: [verifiedContainer],
-          });
-
-          let threadchannel = await sendmessage.startThread({
-            name: `${user.username}'s log`,
-          });
-
-          if (threadEmbed) {
-            await threadchannel.send({ embeds: [threadEmbed] });
-          }
-          await threadchannel.setArchived(true);
-          if (interaction.message.thread) {
-            await interaction.message.thread.delete();
-          }
-
-          await message.delete().catch(console.error);
-        } else {
-          let originalembed = message.embeds[0];
-
-          let Embed = new EmbedBuilder(originalembed)
-            .setColor("#EB2121")
-            .setTitle(originalembed.title + " (DENIED)")
-            .setFooter({
-              text: `Denied by ${interaction.user.username} | ${originalembed?.footer?.text || userid}`,
-            })
-            .setDescription(`**Denied for reason:** ${reason}`);
-
-          await logChannel.send({ content: `<@${userid}>`, embeds: [Embed] });
-          await message.delete().catch(console.error);
-        }
-      }
+  // Process log messages
+  try {
+    await processLogMessages({
+      interaction,
+      client,
+      application,
+      messageids,
+      user: member,
+      status: VerificationStatus.DENIED,
+      reason,
+      useRateLimiting: false,
+    });
+  } catch (logError) {
+    if (logError.code === 50001 || logError.code === 50013) {
+      console.warn(`Missing permissions for log messages in guild ${interaction.guild.id}`);
+      await interaction.followUp({
+        content: "Warning: Could not process log messages due to missing permissions.",
+        flags: MessageFlags.Ephemeral,
+      }).catch(() => {});
+    } else {
+      throw logError;
     }
-  } else {
+  }
+
+  // If no separate log channel, edit the current message
+  if (!application.verifylogs || application.reviewchannel === application.verifylogs) {
     if (interaction.message.flags.has(MessageFlags.IsComponentsV2)) {
-      const verifiedContainer = await handleV2edit(
-        interaction,
-        interaction.message,
-        reason,
+      const { container, files } = relinkAttachments(interaction.message);
+
+      const tempMsg = { ...interaction.message, components: [container] };
+      const deniedContainer = handleV2Edit(
+        interaction, 
+        tempMsg, 
+        VerificationStatus.DENIED,
+        reason
       );
 
-      await interaction.editReply({
+      const editPayload = {
         flags: [MessageFlags.IsComponentsV2],
-        components: [verifiedContainer],
-      });
+        components: [deniedContainer],
+      };
+      if (files) editPayload.files = files;
+      await interaction.editReply(editPayload);
 
       if (interaction.message.thread) {
         await interaction.message.thread.setArchived(true);
       }
-    } else {
-      const originalEmbed = interaction.message.embeds[0];
-      let fields = originalEmbed.fields || [];
-
-      // Remove confirmation field
-      if (
-        fields.length > 0 &&
-        fields[fields.length - 1].name.includes("Are you sure")
-      ) {
-        fields.pop();
-      }
-
-      const embed = new EmbedBuilder(originalEmbed)
-        .setColor("#EB2121")
-        .setTitle(originalEmbed.title + " (DENIED)")
-        .setFields(fields)
-        .setFooter({
-          text: `Denied by ${interaction.user.username} | ${originalEmbed?.footer?.text || userid}`,
-        })
-        .setDescription(`**Denied for reason:** ${reason}`);
-
-      await interaction.editReply({ embeds: [embed], components: [] });
-    }
-
-    if (messageids && messageids.length > 0) {
-      for (const messageId of messageids) {
-        if (messageId === interaction.message.id) {
-          continue;
-        }
-
-        try {
-          const message = await interaction.channel.messages.fetch(messageId);
-          await new Promise((resolve) => setTimeout(resolve, 1000));
-
-          if (message && message.author.id === client.user.id) {
-            if (message.flags.has(MessageFlags.IsComponentsV2)) {
-              const editedContainer = await handleV2edit(
-                interaction,
-                message,
-                reason,
-              );
-              await message.edit({
-                flags: [MessageFlags.IsComponentsV2],
-                components: [editedContainer],
-              });
-            } else if (!message?.embeds[0]?.footer?.text?.includes("Denied")) {
-              const originalembed = message.embeds[0];
-
-              let Embed = new EmbedBuilder(originalembed)
-                .setColor("#EB2121")
-                .setTitle(originalembed.title + " (DENIED)")
-                .setFooter({
-                  text: `Denied by ${interaction.user.username} | ${originalembed?.footer?.text || userid}`,
-                })
-                .setDescription(`**Denied for reason:** ${reason}`);
-
-              await message.edit({ embeds: [Embed], components: [] });
-            }
-          }
-        } catch (error) {
-          console.error(
-            `Failed to process message with ID ${messageId}: ${error}`,
-          );
-        }
-      }
     }
   }
 
-  //delete the message ids from verifications
+  // Cleanup verification data
   if (messageids && messageids.length > 0) {
-    delete verification.guildVerifications[interaction.guild.id];
-    verification.changed("guildVerifications", true);
-    await verification.save();
+    await cleanupVerificationData(verification, interaction.guild.id);
   }
 
-  const denyEmbed = new EmbedBuilder()
-    .setColor("#EB2121")
-    .setTitle("Application Denied")
-    .setDescription(
-      `Your application into **${interaction.guild.name}** has been denied!\n**Reason:** ${interaction.fields.getTextInputValue("denyInput")}`,
-    );
+  // Send denial DM
+  const dmResult = await sendDenyDM(user, interaction.guild.name, reason);
 
-  try {
-    await user.send({ embeds: [denyEmbed] });
+  if (dmResult.dmDisabled) {
+    await interaction.followUp({
+      content: `✅ User denied successfully\n⚠️ Unable to send a DM as this user has their DMs disabled or has blocked the bot.`,
+      flags: MessageFlags.Ephemeral,
+    });
+  } else {
     await interaction.followUp({
       content: `✅ User denied successfully!`,
       flags: MessageFlags.Ephemeral,
     });
-  } catch (error) {
-    if (error.code === 50007 || error.code === 50278) {
-      await interaction.followUp({
-        content: `✅ User denied successfully\n⚠️ Unable to send a DM as this user has their DMs disabled or has blocked the bot.`,
-        flags: MessageFlags.Ephemeral,
-      });
-    } else {
-      throw error;
-    }
   }
 };
-
-async function handleV2edit(interaction, message, reason) {
-  const editedContainer = new ContainerBuilder({
-    accent_color: 0xeb2121,
-  });
-
-  const originalContainer = message.components[0];
-
-  if (originalContainer?.components) {
-    for (const component of originalContainer.components) {
-      if (component.type === 9) {
-        let content = component.components[0].content;
-
-        content = content.replace(/<@&\d+>/g, "").trim();
-
-        editedContainer.addSectionComponents(
-          new SectionBuilder()
-            .addTextDisplayComponents(
-              new TextDisplayBuilder({
-                content:
-                  content +
-                  `\n**Status:** \`Denied by ${interaction.user.username}\`: ${reason}`,
-              }),
-            )
-            .setThumbnailAccessory(
-              new ThumbnailBuilder({
-                media: { url: component.accessory.media.url },
-              }),
-            ),
-        );
-      }
-      if (component.type === 10) {
-        editedContainer.addTextDisplayComponents(
-          new TextDisplayBuilder({
-            content: component.content,
-          }),
-        );
-      } else if (component.type === 14) {
-        editedContainer.addSeparatorComponents(
-          new SeparatorBuilder({
-            spacing: component.spacing || SeparatorSpacingSize.Small,
-          }),
-        );
-      } else if (component.type === 12) {
-        if (component.items?.length > 0) {
-          const mappedurls = component.items?.map((item) => ({
-            media: {
-              url: item.media.url,
-            },
-          }));
-          editedContainer.addMediaGalleryComponents(
-            new MediaGalleryBuilder({
-              items: mappedurls,
-            }),
-          );
-        }
-      }
-    }
-  }
-
-  editedContainer.addTextDisplayComponents(
-    new TextDisplayBuilder({
-      content: `-# Denied by ${interaction.user.username} (${interaction.user.id})`,
-    }),
-  );
-
-  return editedContainer;
-}


### PR DESCRIPTION
- If an application is too long it will attach a .txt with the whole transcript of the application.
- Better handling of too long applications by first truncating questions before the answers.
- Code has been adjusted so this attachment is preserved in all interactions using relinkAttachments
- Refactor so action and reason deny also make use of the shared verificationHandler which makes future editing way easier.
- Better error handling at verifybutton.js, which uses user.send instead of .editReply() as editreply webhook fails after 15 minutes.
- Fixed inconsistency when clicking "Accept" button (now displays Confirm Accept, instead of Confirm Verification)