### PR TITLE
Fix leave update & verification ID per application

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -3,25 +3,15 @@ const path = require("node:path");
 const {
   Client,
   IntentsBitField,
-  EmbedBuilder,
-  ButtonBuilder,
-  ActionRowBuilder,
   Partials,
   AuditLogEvent,
   PermissionsBitField,
   Options,
-  MessageFlags,
-  ContainerBuilder,
-  TextDisplayBuilder,
-  SeparatorBuilder,
-  SeparatorSpacingSize,
-  MediaGalleryBuilder,
-  SectionBuilder,
-  ThumbnailBuilder,
 } = require("discord.js");
 require("dotenv").config();
 const { updateBotJoins, updateBotLeaves } = require("./js/tempconfigfuncs.js");
-const { ServerConfig, Verification, Status } = require("./dbObjects.js");
+const { processLeaveMessages, cleanupVerificationData, getMessageIds } = require("./js/verificationHandler.js");
+const { ServerConfig, Verification, Status, Application } = require("./dbObjects.js");
 const InviteManager = require("./js/dinvite.js");
 const ErrorHandler = require("./js/ErrorHandling.js");
 const RateLimitError = require("./js/RateLimitHandling.js");
@@ -243,113 +233,16 @@ async function createBot(token) {
     }
   });
 
-  function createLeftV2Component(originalMessage, member) {
-    const leftContainer = new ContainerBuilder({
-      accent_color: 0x808080,
-    });
-
-    const originalContainer = originalMessage.components[0];
-
-    if (originalContainer?.components) {
-      for (const component of originalContainer.components) {
-        if (component.type === 9) {
-          // Section component
-          let content = component.components[0].content;
-
-          content = content.replace(/<@&\d+>/g, "").trim();
-
-          leftContainer.addSectionComponents(
-            new SectionBuilder()
-              .addTextDisplayComponents(
-                new TextDisplayBuilder({
-                  content: content + `\n**Status:** \`Left Server\``,
-                }),
-              )
-              .setThumbnailAccessory(
-                new ThumbnailBuilder({
-                  media: { url: component.accessory.media.url },
-                }),
-              ),
-          );
-        } else if (component.type === 10) {
-          // Text display component
-          leftContainer.addTextDisplayComponents(
-            new TextDisplayBuilder({
-              content: component.content,
-            }),
-          );
-        } else if (component.type === 14) {
-          // Separator component
-          leftContainer.addSeparatorComponents(
-            new SeparatorBuilder({
-              spacing: component.spacing || SeparatorSpacingSize.Small,
-            }),
-          );
-        } else if (component.type === 12) {
-          // Media gallery component
-          if (component.items?.length > 0) {
-            const mappedurls = component.items?.map((item) => ({
-              media: {
-                url: item.media.url,
-              },
-            }));
-            leftContainer.addMediaGalleryComponents(
-              new MediaGalleryBuilder({
-                items: mappedurls,
-              }),
-            );
-          }
-        }
-      }
-    }
-
-    leftContainer.addTextDisplayComponents(
-      new TextDisplayBuilder({
-        content: `-# User left server (${member.id})`,
-      }),
-    );
-
-    return leftContainer;
-  }
-
-  const disverify = new ActionRowBuilder().addComponents(
-    new ButtonBuilder()
-      .setCustomId("verify")
-      .setLabel("Accept")
-      .setStyle("Success")
-      .setDisabled(true),
-    new ButtonBuilder()
-      .setCustomId("deny")
-      .setLabel("Deny")
-      .setStyle("Danger")
-      .setDisabled(true),
-    new ButtonBuilder()
-      .setCustomId("reasondeny")
-      .setLabel("Deny with reason")
-      .setStyle("Danger")
-      .setDisabled(true),
-    new ButtonBuilder()
-      .setCustomId("question")
-      .setLabel("Question")
-      .setStyle("Primary")
-      .setDisabled(true),
-    new ButtonBuilder()
-      .setCustomId("action")
-      .setLabel("Kick")
-      .setStyle("Secondary")
-      .setDisabled(true),
-  );
-
   client.on("guildMemberRemove", async (member) => {
     if (!member?.guild?.id || !member.id) return;
 
-    let serverConfig, verification;
+    let applications, verification;
 
     try {
-      [serverConfig, verification] = await Promise.all([
-        ServerConfig.findOne({
+      [applications, verification] = await Promise.all([
+        Application.findAll({
           where: { server_id: member.guild.id },
-          attributes: ["reviewchannel", "verifylogs"],
+          attributes: ["id", "reviewchannel", "verifylogs"],
         }),
         Verification.findOne({
           where: { userId: member.id },
@@ -361,10 +254,10 @@ async function createBot(token) {
       return;
     }
 
-    if (!serverConfig || !verification) return;
+    if (!applications?.length || !verification) return;
 
-    const messageIds = verification?.guildVerifications?.[member.guild.id];
-    if (!messageIds || !Array.isArray(messageIds) || !messageIds.length) return;
+    const guildData = verification?.guildVerifications?.[member.guild.id];
+    if (!guildData) return;
 
     let wasKicked = false;
     const botMember = member.guild.members.cache.get(client.user.id);
@@ -391,197 +284,20 @@ async function createBot(token) {
       }
     }
 
-    if (
-      serverConfig.verifylogs &&
-      messageIds &&
-      serverConfig.reviewchannel !== serverConfig.verifylogs
-    ) {
-      const reviewChannel = member.guild.channels.cache.get(
-        serverConfig.reviewchannel,
-      );
-      const logChannel = member.guild.channels.cache.get(
-        serverConfig.verifylogs,
-      );
+    for (const app of applications) {
+      const appMessageIds = getMessageIds(verification, member.guild.id, app.id);
+      if (!appMessageIds || appMessageIds.length === 0) continue;
 
-      if (logChannel && reviewChannel && messageIds) {
-        // Get all messages in chronological order
-        const messages = [];
-        for (const messageId of messageIds) {
-          try {
-            const message = await reviewChannel.messages.fetch(messageId);
-            if (message) messages.push(message);
-            await new Promise((resolve) => setTimeout(resolve, 300));
-          } catch (error) {
-            if (error.code === 10008) {
-              console.log(`Message ${messageId} not found - skipping`);
-              continue;
-            }
-            throw error;
-          }
-        }
-
-        // Sort by timestamp
-        messages.sort((a, b) => a.createdTimestamp - b.createdTimestamp);
-
-        for (const message of messages) {
-          await new Promise((resolve) => setTimeout(resolve, 600));
-
-          try {
-            if (message.flags.has(MessageFlags.IsComponentsV2)) {
-              const leftContainer = createLeftV2Component(message, member);
-
-              let threadEmbed;
-
-              if (message.thread) {
-                threadEmbed = new EmbedBuilder()
-                  .setTitle(`Thread Summary`)
-                  .setColor("#808080");
-
-                try {
-                  const threadMessages = await message.thread.messages.fetch();
-
-                  if (threadMessages.size > 1) {
-                    const messagesArray = Array.from(threadMessages.values())
-                      .sort((a, b) => a.createdTimestamp - b.createdTimestamp)
-                      .slice(1);
-
-                    const formattedMessages = messagesArray?.map((msg) => {
-                      let content;
-
-                      if (msg.flags.has(MessageFlags.IsComponentsV2)) {
-                        content =
-                          msg.components?.[0]?.components?.[0]?.content ||
-                          "No content";
-                      } else {
-                        content = msg.content || "No content";
-                      }
-
-                      if (msg.author.id === client.user.id) {
-                        content = content?.replace(
-                          /### Question answered by[^\n]*\n?/g,
-                          "\n",
-                        );
-                      }
-
-                      return `\`${msg.author.username}:\` ${content}`;
-                    });
-
-                    const finalContent = formattedMessages
-                      .join("\n")
-                      .slice(0, 4096);
-                    threadEmbed.setDescription(
-                      finalContent || "No messages in thread",
-                    );
-                  } else {
-                    threadEmbed.setDescription(
-                      "No additional messages in thread",
-                    );
-                  }
-                } catch (error) {
-                  console.error("Error fetching thread messages:", error);
-                  threadEmbed.setDescription("Error loading thread messages");
-                }
-              }
-
-              const sendmessage = await logChannel.send({
-                flags: [MessageFlags.IsComponentsV2],
-                components: [leftContainer],
-              });
-
-              const threadchannel = await sendmessage.startThread({
-                name: `${member.user?.username || member.id}'s log`,
-              });
-
-              if (threadEmbed) {
-                await threadchannel.send({ embeds: [threadEmbed] });
-              }
-              await threadchannel.setArchived(true);
-
-              if (message.thread) {
-                await message.thread.delete().catch(console.error);
-              }
-
-              await message.delete().catch(console.error);
-            } else {
-              const originalembed = message.embeds[0];
-
-              const Embed = new EmbedBuilder(originalembed)
-                .setColor("#808080")
-                .setTitle(originalembed.title + " (LEFT)")
-                .setFooter({
-                  text: `Left | ${originalembed?.footer?.text || member.id}`,
-                });
-
-              await logChannel.send({
-                content: `<@${member.id}>`,
-                embeds: [Embed],
-              });
-              await message.delete().catch(console.error);
-            }
-          } catch (error) {
-            console.error(`Error processing log message:`, error);
-          }
-        }
-      }
-    } else {
-      const reviewChannel = member.guild.channels.cache.get(
-        serverConfig.reviewchannel,
-      );
-      if (!reviewChannel) return;
-
-      if (messageIds && messageIds.length > 0) {
-        for (const messageId of messageIds) {
-          try {
-            const message = await reviewChannel.messages.fetch(messageId);
-            await new Promise((resolve) => setTimeout(resolve, 1000));
-
-            if (
-              message &&
-              message.author.id === client.user.id &&
-              !message.embeds[0]?.footer?.text?.includes("Left")
-            ) {
-              if (message.flags.has(MessageFlags.IsComponentsV2)) {
-                const leftContainer = createLeftV2Component(message, member);
-                await message.edit({
-                  flags: [MessageFlags.IsComponentsV2],
-                  components: [leftContainer, disverify],
-                });
-
-                if (message.thread) {
-                  await message.thread.setArchived(true);
-                }
-              } else if (!message?.embeds[0]?.footer?.text?.includes("Left")) {
-                const originalembed = message.embeds[0];
-
-                const Embed = new EmbedBuilder(originalembed)
-                  .setColor("#808080")
-                  .setTitle(originalembed.title + " (LEFT)")
-                  .setFooter({
-                    text: `Left | ${originalembed?.footer?.text || member.id}`,
-                  });
-
-                await message.edit({
-                  embeds: [Embed],
-                  components: [disverify],
-                });
-              }
-            }
-          } catch (error) {
-            console.error(
-              `Failed to process message with ID ${messageId}: ${error}`,
-            );
-          }
-        }
-      }
+      await processLeaveMessages({
+        client,
+        member,
+        application: app,
+        messageIds: appMessageIds,
+      });
     }
 
-    // Clean up verification data
     try {
-      if (messageIds && messageIds.length > 0) {
-        delete verification.guildVerifications[member.guild.id];
-        verification.changed("guildVerifications", true);
-        await verification.save();
-      }
+      await cleanupVerificationData(verification, member.guild.id);
     } catch (error) {
       console.error("Failed to update verification:", error);
     }

--- a/button_commands/actionconfirm.js
+++ b/button_commands/actionconfirm.js
@@ -3,7 +3,7 @@ const {
   PermissionsBitField,
   MessageFlags,
 } = require("discord.js");
-const { Verification } = require("../dbObjects.js");
+const { Verification, Application } = require("../dbObjects.js");
 const {
   checkManagerPermission,
   handleV2Edit,
@@ -114,28 +114,31 @@ module.exports = async ({ interaction, client, userid, context, applicationId })
   const verification = await Verification.findOne({
     where: { userId: userid },
   });
-  const messageids = getMessageIds(verification, interaction.guild.id, applicationId);
 
-  // Process log messages
-  try {
-    await processLogMessages({
-      interaction,
-      client,
-      application,
-      messageids,
-      user: member,
-      status: VerificationStatus.KICKED,
-      useRateLimiting: false,
-    });
-  } catch (logError) {
-    if (logError.code === 50001 || logError.code === 50013) {
-      console.warn(`Missing permissions for log messages in guild ${interaction.guild.id}`);
-      await interaction.followUp({
-        content: "Warning: Could not process log messages due to missing permissions.",
-        flags: MessageFlags.Ephemeral,
-      }).catch(() => {});
-    } else {
-      throw logError;
+  const allApplications = await Application.findAll({
+    where: { server_id: interaction.guild.id },
+    attributes: ["id", "reviewchannel", "verifylogs"],
+  });
+
+  // Edit messages from all applications
+  for (const app of allApplications) {
+    const appMessageIds = getMessageIds(verification, interaction.guild.id, app.id);
+    if (!appMessageIds || appMessageIds.length === 0) continue;
+
+    try {
+      await processLogMessages({
+        interaction,
+        client,
+        application: app,
+        messageids: appMessageIds,
+        user: member,
+        status: VerificationStatus.KICKED,
+        useRateLimiting: false,
+      });
+    } catch (logError) {
+      if (!logError.code === 50001 || !logError.code === 50013) {
+        console.error("Error processing log messages:", logError);
+      }
     }
   }
 
@@ -146,8 +149,8 @@ module.exports = async ({ interaction, client, userid, context, applicationId })
 
       const tempMsg = { ...interaction.message, components: [container] };
       const kickedContainer = handleV2Edit(
-        interaction, 
-        tempMsg, 
+        interaction,
+        tempMsg,
         VerificationStatus.KICKED
       );
 
@@ -164,7 +167,6 @@ module.exports = async ({ interaction, client, userid, context, applicationId })
     }
   }
 
-  if (messageids && messageids.length > 0) {
-    await cleanupVerificationData(verification, interaction.guild.id, applicationId);
-  }
+  // Cleanup verification data for entire guild (user is kicked from server)
+  await cleanupVerificationData(verification, interaction.guild.id);
 };

--- a/button_commands/actionconfirm.js
+++ b/button_commands/actionconfirm.js
@@ -11,6 +11,7 @@ const {
   relinkAttachments,
   processLogMessages,
   cleanupVerificationData,
+  getMessageIds,
 } = require("../js/verificationHandler.js");
 const { getApplicationByIdWithFallback } = require("../js/tempconfigfuncs.js");
 
@@ -113,7 +114,7 @@ module.exports = async ({ interaction, client, userid, context, applicationId })
   const verification = await Verification.findOne({
     where: { userId: userid },
   });
-  const messageids = verification?.guildVerifications?.[interaction.guild.id];
+  const messageids = getMessageIds(verification, interaction.guild.id, applicationId);
 
   // Process log messages
   try {
@@ -164,6 +165,6 @@ module.exports = async ({ interaction, client, userid, context, applicationId })
   }
 
   if (messageids && messageids.length > 0) {
-    await cleanupVerificationData(verification, interaction.guild.id);
+    await cleanupVerificationData(verification, interaction.guild.id, applicationId);
   }
 };

--- a/button_commands/denyconfirm.js
+++ b/button_commands/denyconfirm.js
@@ -8,6 +8,7 @@ const {
   processLogMessages,
   cleanupVerificationData,
   sendDenyDM,
+  getMessageIds,
 } = require("../js/verificationHandler.js");
 const { getApplicationByIdWithFallback } = require("../js/tempconfigfuncs.js");
 
@@ -49,7 +50,7 @@ module.exports = async ({ interaction, client, userid, context, applicationId })
 
   // Get verification data
   const verification = await Verification.findOne({ where: { userId: userid } });
-  const messageids = verification?.guildVerifications?.[interaction.guild.id];
+  const messageids = getMessageIds(verification, interaction.guild.id, applicationId);
 
   // Try to get member for processLogMessages
   let member;
@@ -109,7 +110,7 @@ module.exports = async ({ interaction, client, userid, context, applicationId })
 
   // Cleanup verification data
   if (messageids && messageids.length > 0) {
-    await cleanupVerificationData(verification, interaction.guild.id);
+    await cleanupVerificationData(verification, interaction.guild.id, applicationId);
   }
 
   // Send denial DM

--- a/button_commands/verifybutton.js
+++ b/button_commands/verifybutton.js
@@ -21,6 +21,7 @@ const {
 const { v4: uuidv4 } = require("uuid");
 const { updateVerifications, getApplicationByIdWithFallback } = require("../js/tempconfigfuncs.js");
 const { resolveImage } = require("../js/imageUtils.js");
+const { addMessageId } = require("../js/verificationHandler.js");
 
 const activeVerifications = new Map();
 
@@ -1137,28 +1138,16 @@ async function processVerificationResult(
     }
     
     try {
-      const verification = await Verification.findOne({
+      let verification = await Verification.findOne({
         where: { userId: user.id },
       });
       if (verification) {
-        if (
-          verification?.guildVerifications &&
-          verification?.guildVerifications?.[guildId]
-        ) {
-          verification.guildVerifications[guildId].push(channelsent.id);
-        } else {
-          verification.guildVerifications = {
-            ...verification.guildVerifications,
-            [guildId]: [channelsent.id],
-          };
-        }
-        verification.changed("guildVerifications", true);
-
+        addMessageId(verification, guildId, applicationId, channelsent.id);
         await verification.save();
       } else {
         await Verification.create({
           userId: user.id,
-          guildVerifications: { [guildId]: [channelsent.id] },
+          guildVerifications: { [guildId]: { [applicationId]: [channelsent.id] } },
         });
       }
     } catch (error) {

--- a/button_commands/verifyconfirm.js
+++ b/button_commands/verifyconfirm.js
@@ -11,6 +11,7 @@ const {
   sendWelcomeMessage,
   sendVerifyDM,
   applyRoles,
+  getMessageIds,
 } = require("../js/verificationHandler.js");
 const { getApplicationById } = require("../js/tempconfigfuncs.js");
 
@@ -112,7 +113,7 @@ module.exports = async ({ interaction, client, userid, context, applicationId })
 
   // Get verification data
   const verification = await Verification.findOne({ where: { userId: userid } });
-  const messageids = verification?.guildVerifications?.[interaction.guild.id];
+  const messageids = getMessageIds(verification, interaction.guild.id, applicationId);
 
   // Process log messages
   await processLogMessages({
@@ -152,7 +153,7 @@ module.exports = async ({ interaction, client, userid, context, applicationId })
 
   // Cleanup verification data
   if (messageids && messageids.length > 0) {
-    await cleanupVerificationData(verification, interaction.guild.id);
+    await cleanupVerificationData(verification, interaction.guild.id, applicationId);
   }
 
   // Send verification DM

--- a/commands/utility/deny.js
+++ b/commands/utility/deny.js
@@ -12,6 +12,7 @@ const {
   cleanupVerificationData,
   sendDenyDM,
   createNoApplicationEmbed,
+  getMessageIds,
 } = require("../../js/verificationHandler.js");
 
 module.exports = {
@@ -156,7 +157,7 @@ module.exports = {
 
         // Get verification data
         const verification = await Verification.findOne({ where: { userId: userID } });
-        const messageids = verification?.guildVerifications?.[interaction.guild.id] || [];
+        const messageids = getMessageIds(verification, interaction.guild.id, application.id);
         const invitetracker = await InviteTracker.findOne({
           where: { unique_id: `${userID}_${interaction.guild.id}` },
         });
@@ -198,7 +199,7 @@ module.exports = {
 
         // Cleanup verification data
         if (messageids && messageids.length > 0) {
-          await cleanupVerificationData(verification, interaction.guild.id);
+          await cleanupVerificationData(verification, interaction.guild.id, application.id);
         }
 
         // Send denial DM

--- a/commands/utility/verify.js
+++ b/commands/utility/verify.js
@@ -16,6 +16,7 @@ const {
   sendVerifyDM,
   applyRoles,
   createNoApplicationEmbed,
+  getMessageIds,
 } = require("../../js/verificationHandler.js");
 
 module.exports = {
@@ -180,7 +181,7 @@ module.exports = {
 
         // Get verification data
         const verification = await Verification.findOne({ where: { userId: userID } });
-        const messageids = verification?.guildVerifications?.[interaction.guild.id] || [];
+        const messageids = getMessageIds(verification, interaction.guild.id, application.id);
         const invitetracker = await InviteTracker.findOne({
           where: { unique_id: `${userID}_${interaction.guild.id}` },
         });
@@ -222,7 +223,7 @@ module.exports = {
 
         // Cleanup verification data
         if (messageids && messageids.length > 0) {
-          await cleanupVerificationData(verification, interaction.guild.id);
+          await cleanupVerificationData(verification, interaction.guild.id, application.id);
         }
 
         // Send welcome message

--- a/js/verificationHandler.js
+++ b/js/verificationHandler.js
@@ -11,20 +11,59 @@ const {
   PermissionsBitField,
   FileBuilder,
   AttachmentBuilder,
+  ButtonBuilder,
+  ActionRowBuilder,
 } = require("discord.js");
 const { Verification, InviteTracker } = require("../dbObjects.js");
 const { resolveImage } = require("./imageUtils.js");
+
+function getMessageIds(verification, guildId, applicationId = null) {
+  const guildData = verification?.guildVerifications?.[guildId];
+  if (!guildData) return [];
+
+  if (Array.isArray(guildData)) {
+    return guildData;
+  }
+
+  if (applicationId != null) {
+    return guildData[applicationId] || [];
+  }
+
+  return Object.values(guildData).flat();
+}
+
+function addMessageId(verification, guildId, applicationId, messageId) {
+  if (!verification.guildVerifications) {
+    verification.guildVerifications = {};
+  }
+
+  let guildData = verification.guildVerifications[guildId];
+
+  if (!guildData || Array.isArray(guildData)) {
+    verification.guildVerifications[guildId] = {};
+    guildData = verification.guildVerifications[guildId];
+  }
+
+  if (!guildData[applicationId]) {
+    guildData[applicationId] = [];
+  }
+
+  guildData[applicationId].push(messageId);
+  verification.changed("guildVerifications", true);
+}
 
 const VerificationStatus = {
   VERIFIED: "verified",
   DENIED: "denied",
   KICKED: "kicked",
+  LEFT: "left",
 };
 
 const StatusColors = {
   [VerificationStatus.VERIFIED]: 0x008000,
   [VerificationStatus.DENIED]: 0xeb2121,
   [VerificationStatus.KICKED]: 0xeb2121,
+  [VerificationStatus.LEFT]: 0x808080,
 };
 
 async function rateLimitedOperation(operation, maxRetries = 3) {
@@ -254,6 +293,130 @@ function handleV2Edit(interaction, message, status, reason = null) {
   );
 
   return editedContainer;
+}
+
+function createLeftV2Component(message, memberId) {
+  const MAX_DISPLAYABLE_TEXT = 4000;
+  const color = StatusColors[VerificationStatus.LEFT];
+
+  const footerText = `-# User left server (${memberId})`;
+  const statusSuffix = `\n**Status:** \`Left Server\``;
+  const reservedChars = footerText.length + 50;
+  let totalTextLength = 0;
+
+  const clonedContainer = JSON.parse(
+    JSON.stringify(message.components[0] || {}),
+  );
+  const editedContainer = new ContainerBuilder({
+    accent_color: color,
+  });
+
+  if (clonedContainer.components) {
+    for (const component of clonedContainer.components) {
+      if (component.type === 9) {
+        let content = component.components[0].content;
+        content = content.replace(/<@&\d+>/g, "").trim();
+
+        const fullContent = content + statusSuffix;
+        const available = MAX_DISPLAYABLE_TEXT - totalTextLength - reservedChars;
+        const truncatedContent = available < fullContent.length
+            ? fullContent.slice(0, Math.max(available - 3, 0)) + "..."
+            : fullContent;
+
+        totalTextLength += truncatedContent.length;
+
+        editedContainer.addSectionComponents(
+          new SectionBuilder()
+            .addTextDisplayComponents(
+              new TextDisplayBuilder({
+                content: truncatedContent,
+              }),
+            )
+            .setThumbnailAccessory(
+              new ThumbnailBuilder({
+                media: { url: component.accessory.media.url },
+              }),
+            ),
+        );
+      } else if (component.type === 10) {
+        const available = MAX_DISPLAYABLE_TEXT - totalTextLength - reservedChars;
+        if (available <= 0) continue;
+
+        const content = available < component.content.length
+            ? component.content.slice(0, Math.max(available - 3, 0)) + "..."
+            : component.content;
+
+        totalTextLength += content.length;
+
+        editedContainer.addTextDisplayComponents(
+          new TextDisplayBuilder({
+            content: content,
+          }),
+        );
+      } else if (component.type === 14) {
+        editedContainer.addSeparatorComponents(
+          new SeparatorBuilder({
+            spacing: component.spacing || SeparatorSpacingSize.Small,
+          }),
+        );
+      } else if (component.type === 12) {
+        if (component.items?.length > 0) {
+          const mappedurls = component.items.map((item) => ({
+            media: { url: item.media.url },
+          }));
+          editedContainer.addMediaGalleryComponents(
+            new MediaGalleryBuilder({
+              items: mappedurls,
+            }),
+          );
+        }
+      } else if (component.type === 13) {
+        if (component.file?.url?.startsWith("attachment://")) {
+          editedContainer.addFileComponents(
+            new FileBuilder().setURL(component.file.url),
+          );
+        }
+      }
+    }
+  }
+
+  editedContainer.addTextDisplayComponents(
+    new TextDisplayBuilder({
+      content: footerText,
+    }),
+  );
+
+  return editedContainer;
+}
+
+function createDisabledButtons() {
+  return new ActionRowBuilder().addComponents(
+    new ButtonBuilder()
+      .setCustomId("verify")
+      .setLabel("Accept")
+      .setStyle("Success")
+      .setDisabled(true),
+    new ButtonBuilder()
+      .setCustomId("deny")
+      .setLabel("Deny")
+      .setStyle("Danger")
+      .setDisabled(true),
+    new ButtonBuilder()
+      .setCustomId("reasondeny")
+      .setLabel("Deny with reason")
+      .setStyle("Danger")
+      .setDisabled(true),
+    new ButtonBuilder()
+      .setCustomId("question")
+      .setLabel("Question")
+      .setStyle("Primary")
+      .setDisabled(true),
+    new ButtonBuilder()
+      .setCustomId("action")
+      .setLabel("Kick")
+      .setStyle("Secondary")
+      .setDisabled(true),
+  );
 }
 
 // Process text placeholders for welcome messages
@@ -673,13 +836,120 @@ async function processLogMessages(options) {
   }
 }
 
-// Clean up verification data from database
-async function cleanupVerificationData(verification, guildId) {
-  if (verification?.guildVerifications?.[guildId]) {
-    delete verification.guildVerifications[guildId];
-    verification.changed("guildVerifications", true);
-    await verification.save();
+async function processLeaveMessages(options) {
+  const { client, member, application, messageIds } = options;
+
+  const reviewChannel = member.guild.channels.cache.get(application.reviewchannel);
+  if (!reviewChannel) return;
+
+  const hasSeparateLogChannel =
+    application.verifylogs && application.verifylogs !== application.reviewchannel;
+
+  for (const messageId of messageIds) {
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    let foundMessage;
+    try {
+      foundMessage = await reviewChannel.messages.fetch(messageId);
+    } catch (error) {
+      if (error.code === 10008) continue;
+      console.error(`Error fetching message ${messageId}:`, error);
+      continue;
+    }
+
+    if (!foundMessage) continue;
+
+    try {
+      if (hasSeparateLogChannel) {
+        const logChannel =
+          member.guild.channels.cache.get(application.verifylogs);
+
+        if (
+          logChannel &&
+          foundMessage.flags?.has(MessageFlags.IsComponentsV2)
+        ) {
+          await new Promise((resolve) => setTimeout(resolve, 300));
+
+          const { container, files } = relinkAttachments(foundMessage);
+          const tempMsg = { ...foundMessage, components: [container] };
+          const leftContainer = createLeftV2Component(tempMsg, member.id);
+
+          let threadEmbed;
+          if (foundMessage.thread) {
+            threadEmbed = await createThreadSummary(
+              foundMessage.thread,
+              client,
+              VerificationStatus.LEFT,
+            );
+          }
+
+          const payload = {
+            flags: [MessageFlags.IsComponentsV2],
+            components: [leftContainer],
+          };
+          if (files) payload.files = files;
+
+          const sentMessage = await logChannel.send(payload);
+
+          const thread = await sentMessage.startThread({
+            name: `${member.user?.username || member.id}'s log`,
+          });
+
+          if (threadEmbed) {
+            await thread.send({ embeds: [threadEmbed] });
+          }
+          await thread.setArchived(true);
+
+          if (foundMessage.thread) {
+            await foundMessage.thread.delete().catch(console.error);
+          }
+          await foundMessage.delete().catch(console.error);
+        }
+      } else {
+        if (
+          foundMessage.author.id === client.user.id &&
+          foundMessage.flags?.has(MessageFlags.IsComponentsV2)
+        ) {
+          const { container, files } = relinkAttachments(foundMessage);
+          const tempMsg = { ...foundMessage, components: [container] };
+          const leftContainer = createLeftV2Component(tempMsg, member.id);
+          const disabledButtons = createDisabledButtons();
+
+          const editPayload = {
+            flags: [MessageFlags.IsComponentsV2],
+            components: [leftContainer, disabledButtons],
+          };
+          if (files) editPayload.files = files;
+
+          await foundMessage.edit(editPayload);
+
+          if (foundMessage.thread) {
+            await foundMessage.thread.setArchived(true);
+          }
+        }
+      }
+    } catch (error) {
+      console.error("Error processing log message:", error);
+    }
   }
+}
+
+// Clean up verification data from database
+async function cleanupVerificationData(verification, guildId, applicationId = null) {
+  const guildData = verification?.guildVerifications?.[guildId];
+  if (!guildData) return;
+
+  if (applicationId != null && !Array.isArray(guildData)) {
+    delete guildData[applicationId];
+    if (Object.keys(guildData).length === 0) {
+      delete verification.guildVerifications[guildId];
+    }
+  } else {
+    delete verification.guildVerifications[guildId];
+  }
+
+  verification.changed("guildVerifications", true);
+  await verification.save();
 }
 
 // Create "no application" embed for users verified/denied without application
@@ -725,7 +995,7 @@ async function verifyUser(options) {
 
   // Get verification data
   const verification = await Verification.findOne({ where: { userId } });
-  const messageids = verification?.guildVerifications?.[interaction.guild.id] || [];
+  const messageids = getMessageIds(verification, interaction.guild.id, application.id);
   const invitetracker = await InviteTracker.findOne({
     where: { unique_id: `${userId}_${interaction.guild.id}` },
   });
@@ -757,7 +1027,7 @@ async function verifyUser(options) {
 
   // Cleanup verification data
   if (messageids && messageids.length > 0) {
-    await cleanupVerificationData(verification, interaction.guild.id);
+    await cleanupVerificationData(verification, interaction.guild.id, application.id);
   }
 
   // Send welcome message
@@ -799,7 +1069,7 @@ async function denyUser(options) {
 
   // Get verification data
   const verification = await Verification.findOne({ where: { userId } });
-  const messageids = verification?.guildVerifications?.[interaction.guild.id] || [];
+  const messageids = getMessageIds(verification, interaction.guild.id, application.id);
   const invitetracker = await InviteTracker.findOne({
     where: { unique_id: `${userId}_${interaction.guild.id}` },
   });
@@ -831,7 +1101,7 @@ async function denyUser(options) {
 
   // Cleanup verification data
   if (messageids && messageids.length > 0) {
-    await cleanupVerificationData(verification, interaction.guild.id);
+    await cleanupVerificationData(verification, interaction.guild.id, application.id);
   }
 
   // Send deny DM
@@ -876,11 +1146,14 @@ module.exports = {
   relinkAttachments,
   processText,
   getMentions,
+  getMessageIds,
+  addMessageId,
   sendWelcomeMessage,
   sendVerifyDM,
   sendDenyDM,
   createThreadSummary,
   processLogMessages,
+  processLeaveMessages,
   cleanupVerificationData,
   createNoApplicationEmbed,
   verifyUser,

--- a/modal_commands/denyModal.js
+++ b/modal_commands/denyModal.js
@@ -7,6 +7,7 @@ const {
   processLogMessages,
   cleanupVerificationData,
   sendDenyDM,
+  getMessageIds,
 } = require("../js/verificationHandler.js");
 const { getApplicationByIdWithFallback } = require("../js/tempconfigfuncs.js");
 
@@ -33,7 +34,7 @@ module.exports = async ({ interaction, client, userid, applicationId }) => {
       flags: MessageFlags.Ephemeral,
     });
   }
-  const messageids = verification?.guildVerifications?.[interaction.guild.id];
+  const messageids = getMessageIds(verification, interaction.guild.id, applicationId);
   const reason = interaction.fields.getTextInputValue("denyInput");
 
   let member;
@@ -95,7 +96,7 @@ module.exports = async ({ interaction, client, userid, applicationId }) => {
 
   // Cleanup verification data
   if (messageids && messageids.length > 0) {
-    await cleanupVerificationData(verification, interaction.guild.id);
+    await cleanupVerificationData(verification, interaction.guild.id, applicationId);
   }
 
   // Send denial DM


### PR DESCRIPTION
Fixes the old update state when someone leaves that it is reflected in the application. And it fixes when someone filled in multiple applications, and gets verified/denied/etc., that it doesn't mark *all* applications as that state.
- Moves most leave logic out of bot.js and into verificationhandler.
- Update verifications ids to include the application id, so this isn't done per server but per application within a server: { guildId: { applicationId: [msgId] } }