### PR TITLE
Remove max field limit & fix limited answerquestion

### DIFF
--- a/button_commands/answerquestion.js
+++ b/button_commands/answerquestion.js
@@ -135,14 +135,18 @@ module.exports = async ({ interaction, client }) => {
 
   messageCollector.on("collect", async (m) => {
     let totalcontent = m.content;
+    let answercontent = m.content;
     let attachmentUrls = [];
 
     // Truncate if too long
-    if (totalcontent.length > 1024) {
-      totalcontent = totalcontent.substring(0, 1021) + "...";
-      await m.author.send(
-        "Note: Your answer was shortened to fit Discord's limits.",
-      );
+    if (answercontent.length > 1024) {
+      answercontent = answercontent.substring(0, 1021) + "...";
+    }
+
+    const questionform = interaction.message.embeds[0];
+
+    if(totalcontent.length + questionform.fields[0].value.length > 3800) {
+      totalcontent = totalcontent.substring(0, 3800 - questionform.fields[0].value.length) + "...";
     }
 
     const rolesToPing = Array.isArray(application.questionpingrole)
@@ -190,21 +194,9 @@ module.exports = async ({ interaction, client }) => {
       }
     }
 
-    const questionform = interaction.message.embeds[0];
     const answerform = EmbedBuilder.from(questionform)
-      .addFields({ name: "Answer", value: totalcontent })
+      .addFields({ name: "Answer", value: answercontent })
       .setColor("#008000");
-
-    const logresponse = EmbedBuilder.from(questionform)
-      .addFields({ name: "Answer", value: totalcontent })
-      .setAuthor({
-        name: user.tag,
-        iconURL: user.displayAvatarURL({ dynamic: true }),
-      })
-      .setTimestamp()
-      .setFooter({ text: `DM | ${user.id}` });
-
-    delete logresponse.data.title;
 
     await interaction.message.edit({
       components: [disabledconfirmrow],

--- a/button_commands/verifybutton.js
+++ b/button_commands/verifybutton.js
@@ -936,7 +936,6 @@ async function constructApplicationEmbed(
     let totalCharacterCount = 0;
     let absoluteTotalCharacterCount = 0;
     const MAX_TOTAL_CHARACTERS = 3600;
-    const MAX_FIELD_CHARACTERS = 1024;
     let wasTruncated = false;
     const fullTextLines = [];
 
@@ -966,11 +965,6 @@ async function constructApplicationEmbed(
         questionText,
         `_ _ ${answertext}`,
       ].join("\n");
-
-      if (formattedField.length > MAX_FIELD_CHARACTERS) {
-        formattedField = formattedField.slice(0, MAX_FIELD_CHARACTERS - 3) + "...";
-        wasTruncated = true;
-      }
 
       if (totalCharacterCount + formattedField.length > MAX_TOTAL_CHARACTERS) {
         const remainingCharacters = MAX_TOTAL_CHARACTERS - totalCharacterCount;


### PR DESCRIPTION
Removes the max field limit when truncating the final application to fit within liimts. If a user answers with a single long answer but the other answers ones are short then it would truncate the long answer while there would have been enough space available. This way it only truncates globally, not on a per question/answer scale.

Changes truncation logic in answerquestion to only truncate the embed what the user sees in DMs to 1024 characters, but not to the final component that's sent to the review channel (since that's a component not an embed).