### PR TITLE
Fixed send Deny DM

### DIFF
--- a/button_commands/answerquestion.js
+++ b/button_commands/answerquestion.js
@@ -254,17 +254,10 @@ module.exports = async ({ interaction, client }) => {
                 components: [container, replybutton],
               });
             } else {
-              if (verificationMessage) {
-                await verificationMessage.reply({
-                  flags: [MessageFlags.IsComponentsV2],
-                  components: [container, replybutton],
-                });
-              } else { // if verification Message is undefined, use .send instead of .reply
-                verificationChannel.send({
-                  flags: [MessageFlags.IsComponentsV2],
-                  components: [container, replybutton],
-                });
-              }
+              await verificationMessage.reply({
+                flags: [MessageFlags.IsComponentsV2],
+                components: [container, replybutton],
+              });
             }
           }
           return false;

--- a/button_commands/denyconfirm.js
+++ b/button_commands/denyconfirm.js
@@ -114,7 +114,7 @@ module.exports = async ({ interaction, client, userid, context, applicationId })
   }
 
   // Send denial DM
-  const dmResult = await sendDenyDM(user, application, interaction.guild.name);
+  const dmResult = await sendDenyDM(interaction.user.username, user, application, interaction.guild.name);
 
   if (dmResult.dmDisabled) {
     await interaction.followUp({

--- a/commands/utility/deny.js
+++ b/commands/utility/deny.js
@@ -203,7 +203,7 @@ module.exports = {
         }
 
         // Send denial DM
-        await sendDenyDM(user.user, interaction.guild.name);
+        await sendDenyDM(interaction.user.username, user.user, application, interaction.guild.name);
 
         results.success.push(userID);
       } catch (error) {

--- a/modal_commands/denyModal.js
+++ b/modal_commands/denyModal.js
@@ -100,7 +100,7 @@ module.exports = async ({ interaction, client, userid, applicationId }) => {
   }
 
   // Send denial DM
-  const dmResult = await sendDenyDM(user, interaction.guild.name, reason);
+  const dmResult = await sendDenyDM(interaction.user.username, user, application, interaction.guild.name, reason);
 
   if (dmResult.dmDisabled) {
     await interaction.followUp({


### PR DESCRIPTION
Fixed sendDenyDM inputs to include application and modname so the function can actually use the custom values instead of defaulting to defaults or leaving the {modname} placeholder open.