### PR TITLE
Verifybutton bugfixes & better /checkpermissions

### DIFF
--- a/button_commands/reasondeny.js
+++ b/button_commands/reasondeny.js
@@ -38,7 +38,7 @@ module.exports = async ({ interaction, client, userid, applicationId }) => {
   const user = await client.users.fetch(userid);
 
   const modal = new ModalBuilder()
-    .setCustomId(`denyModal_${applicationId}`)
+    .setCustomId(`denyModal_${applicationId}_${userid}`)
     .setTitle(`Deny ${user.tag}`);
 
   const denyinput = new TextInputBuilder()

--- a/button_commands/verifybutton.js
+++ b/button_commands/verifybutton.js
@@ -94,6 +94,8 @@ module.exports = async ({ interaction, client, applicationId }) => {
 
     // Find the application by ID and validate guild ownership
     const { application, error } = await getApplicationByIdWithFallback(applicationId, guildId);
+
+    applicationId = application.id;
     
     if (error || !application) {
       return await interaction.editReply({
@@ -375,6 +377,7 @@ module.exports = async ({ interaction, client, applicationId }) => {
           .broadcastEval(Verificationfunc, {
             context: {
               userid: user.id,
+              dmChannelId: dmChannel.id,
               botQuestions: parsedQuestions,
               startverificationid: startverification.id,
               interactionguild: interaction.guild,
@@ -415,6 +418,7 @@ module.exports = async ({ interaction, client, applicationId }) => {
         try {
           const [reason, responses] = await Verificationfunc(client, {
             userid: user.id,
+            dmChannelId: dmChannel.id,
             botQuestions: parsedQuestions,
             startverificationid: startverification.id,
             interactionguild: interaction.guild,
@@ -452,7 +456,7 @@ module.exports = async ({ interaction, client, applicationId }) => {
 
       async function Verificationfunc(
         c,
-        { userid, botQuestions, startverificationid, cancelbutton, sessionId },
+        { userid, dmChannelId, botQuestions, startverificationid, cancelbutton, sessionId },
       ) {
         return new Promise((resolve, reject) => {
           const {
@@ -476,7 +480,7 @@ module.exports = async ({ interaction, client, applicationId }) => {
           (async () => {
             try {
               const user = await c.users.fetch(userid);
-              const dmChannel = await user.createDM();
+              const dmChannel = await c.channels.fetch(dmChannelId);
               let startverification =
                 await dmChannel.messages.fetch(startverificationid);
 
@@ -893,9 +897,10 @@ module.exports = async ({ interaction, client, applicationId }) => {
     console.error("Verification error:", error);
     // throw error;
 
-    await interaction.user.send({
+    await interaction.followUp({
       content: `An error occurred during the verification process! Please try again later or contact the server staff/[Melpo's Support server](https://discord.gg/jjGAwwwxZz). (${error.message})`,
-    });
+      flags: MessageFlags.Ephemeral
+    }).catch(() => {});
   } finally {
     activeVerifications.delete(interaction.user.id);
   }

--- a/button_commands/verifybutton.js
+++ b/button_commands/verifybutton.js
@@ -484,9 +484,10 @@ module.exports = async ({ interaction, client, applicationId }) => {
                 filter: (m) => !m.author.bot,
                 time: 3600000,
               });
-              const cancelcollector = dmChannel.createMessageComponentCollector(
-                { filter: (i) => i.user.id === user.id, time: 3600000 },
-              );
+              const cancelcollector = dmChannel.createMessageComponentCollector({
+                filter: (i) => i.user.id === user.id, 
+                time: 3600000, 
+              });
 
               const responses = [];
               let isProcessing = false;
@@ -572,6 +573,8 @@ module.exports = async ({ interaction, client, applicationId }) => {
                       content: `${numberToEmoji[answerIndex]} ${mcqanswer}`,
                     };
                     responses.push(responseAnswer);
+                    collector.resetTimer();
+                    cancelcollector.resetTimer();
 
                     if (responses.length < botQuestions.length) {
                       const nextQuestionIndex = responses.length;
@@ -750,6 +753,8 @@ module.exports = async ({ interaction, client, applicationId }) => {
                   };
 
                   responses.push(totalcontent);
+                  collector.resetTimer();
+                  cancelcollector.resetTimer();
 
                   if (responses.length < botQuestions.length) {
                     const nextQuestionIndex = responses.length;
@@ -906,8 +911,13 @@ async function constructApplicationEmbed(
   appName,
 ) {
   const guild = await client.guilds.fetch(serverId);
-  const guildmember = await guild.members.fetch(user.id);
+  let guildmember = null;
 
+  try {
+    guildmember = await guild.members.fetch(user.id);
+  } catch {
+    return;
+  }
   const invitetracker = await InviteTracker.findOne({
     where: { unique_id: `${user.id}_${serverId}` },
   });
@@ -1079,32 +1089,6 @@ async function processVerificationResult(
     // Process collected responses and send to verification review channel
     updateVerifications();
 
-    const finishEmbedTitle = replaceplaceholder(
-      finishmessage?.title,
-      interaction.user.globalName ?? interaction.user.username,
-      interaction.guild.name,
-    );
-    const finishEmbedDescription = replaceplaceholder(
-      finishmessage?.description,
-      interaction.user.globalName ?? interaction.user.username,
-      interaction.guild.name,
-    );
-      const finishEmbedimage = finishmessage?.image;
-      const finishImageAsset = resolveImage(finishEmbedimage);
-
-    const endEmbed = new EmbedBuilder()
-      .setTitle(
-        finishEmbedTitle && finishEmbedTitle.trim() ? finishEmbedTitle : null,
-      )
-      .setDescription(finishEmbedDescription)
-      .setColor(finishmessage?.color || "#008000")
-      .setFooter({ text: `Application: ${appName}` })
-      .setImage(finishImageAsset.embedUrl);
-
-    dmChannel.send({
-      embeds: [endEmbed],
-    });
-
     user = user || interaction.user;
 
     const { container, attachment } = await constructApplicationEmbed(
@@ -1116,6 +1100,12 @@ async function processVerificationResult(
       pingStaffRoleId,
       appName,
     );
+
+    if(!container) {
+      //try to send image to user:
+      dmChannel.send({ content: "An error occurred while processing your verification. This can happen when you left or have been kicked from the server during your application."  }).catch(() => {});
+      return;
+    }
 
     //create the buttons
     const verify = new ActionRowBuilder().addComponents(
@@ -1153,6 +1143,33 @@ async function processVerificationResult(
     }
 
     channelsent = await verifyLogsChannel.send(sendPayload);
+
+    const finishEmbedTitle = replaceplaceholder(
+      finishmessage?.title,
+      interaction.user.globalName ?? interaction.user.username,
+      interaction.guild.name,
+    );
+    const finishEmbedDescription = replaceplaceholder(
+      finishmessage?.description,
+      interaction.user.globalName ?? interaction.user.username,
+      interaction.guild.name,
+    );
+    const finishEmbedimage = finishmessage?.image;
+    const finishImageAsset = resolveImage(finishEmbedimage);
+
+    const endEmbed = new EmbedBuilder()
+      .setTitle(
+        finishEmbedTitle && finishEmbedTitle.trim() ? finishEmbedTitle : null,
+      )
+      .setDescription(finishEmbedDescription)
+      .setColor(finishmessage?.color || "#008000")
+      .setFooter({ text: `Application: ${appName}` })
+      .setImage(finishImageAsset.embedUrl);
+
+    dmChannel.send({
+      embeds: [endEmbed],
+    });
+
     if (useThreads === true) {
       await channelsent.startThread({
         name: `${user.globalName ?? user.username}'s Verification`,

--- a/commands/setup/checkpermissions.js
+++ b/commands/setup/checkpermissions.js
@@ -13,9 +13,9 @@ module.exports = {
       "Check if Melpo has the required permissions to function properly",
     )
     .setContexts(0),
-  async execute({ interaction, client }) {
+  async execute({ interaction }) {
     await interaction.deferReply();
-    const botMember = interaction.guild.members.me;
+    const botMember = await interaction.guild.members.fetchMe();
     if (!botMember) {
       await interaction.reply({
         content: "Unable to fetch bot permissions",
@@ -109,12 +109,15 @@ module.exports = {
         const verifyChannel = interaction.guild.channels.cache.get(
           app.verifychannel,
         );
+        description += `**Verify Channel (${verifyChannel ? verifyChannel : 'Unknown/Deleted'})**\n`;
         if (verifyChannel) {
-          const verifyPerms = verifyChannel.permissionsFor(client.user);
-          description += `**Verify Channel (${verifyChannel})**\n`;
+          const verifyPerms = verifyChannel.permissionsFor(botMember);
           description += `${verifyPerms.has(PermissionsBitField.Flags.ViewChannel) ? "✅" : "❌"} View Channel\n`;
           description += `${verifyPerms.has(PermissionsBitField.Flags.SendMessages) ? "✅" : "❌"} Send Messages\n`;
           description += `${verifyPerms.has(PermissionsBitField.Flags.ReadMessageHistory) ? "✅" : "❌"} Read Message History\n`;
+          description += `${verifyPerms.has(PermissionsBitField.Flags.EmbedLinks) ? "✅" : "❌"} Embed Links\n`;
+        } else {
+          description += `❌ Channel not found or deleted\n`;
         }
       }
 
@@ -122,15 +125,18 @@ module.exports = {
         const reviewChannel = interaction.guild.channels.cache.get(
           app.reviewchannel,
         );
+        description += `\n**Review Channel (${reviewChannel ? reviewChannel : 'Unknown/Deleted'})**\n`;
         if (reviewChannel) {
-          const reviewPerms = reviewChannel.permissionsFor(client.user);
-          description += `\n**Review Channel (${reviewChannel})**\n`;
+          const reviewPerms = reviewChannel.permissionsFor(botMember);
           description += `${reviewPerms.has(PermissionsBitField.Flags.ViewChannel) ? "✅" : "❌"} View Channel\n`;
           description += `${reviewPerms.has(PermissionsBitField.Flags.SendMessages) ? "✅" : "❌"} Send Messages\n`;
           description += `${reviewPerms.has(PermissionsBitField.Flags.ReadMessageHistory) ? "✅" : "❌"} Read Message History\n`;
+          description += `${reviewPerms.has(PermissionsBitField.Flags.EmbedLinks) ? "✅" : "❌"} Embed Links\n`;
           description += `${reviewPerms.has(PermissionsBitField.Flags.CreatePrivateThreads) ? "✅" : "❌"} Create Private Threads\n`;
           description += `${reviewPerms.has(PermissionsBitField.Flags.SendMessagesInThreads) ? "✅" : "❌"} Send Messages In Threads\n`;
           description += `${reviewPerms.has(PermissionsBitField.Flags.ManageThreads) ? "✅" : "❌"} Manage Threads\n`;
+        } else {
+          description += `❌ Channel not found or deleted\n`;
         }
       }
 
@@ -138,15 +144,18 @@ module.exports = {
         const logsChannel = interaction.guild.channels.cache.get(
           app.verifylogs,
         );
+        description += `\n**Verification Logs Channel (${logsChannel ? logsChannel : 'Unknown/Deleted'})**\n`;
         if (logsChannel) {
-          const logsPerms = logsChannel.permissionsFor(client.user);
-          description += `\n**Verification Logs Channel (${logsChannel})**\n`;
+          const logsPerms = logsChannel.permissionsFor(botMember);
           description += `${logsPerms.has(PermissionsBitField.Flags.ViewChannel) ? "✅" : "❌"} View Channel\n`;
           description += `${logsPerms.has(PermissionsBitField.Flags.SendMessages) ? "✅" : "❌"} Send Messages\n`;
           description += `${logsPerms.has(PermissionsBitField.Flags.ReadMessageHistory) ? "✅" : "❌"} Read Message History\n`;
+          description += `${logsPerms.has(PermissionsBitField.Flags.EmbedLinks) ? "✅" : "❌"} Embed Links\n`;
           description += `${logsPerms.has(PermissionsBitField.Flags.CreatePrivateThreads) ? "✅" : "❌"} Create Private Threads\n`;
           description += `${logsPerms.has(PermissionsBitField.Flags.SendMessagesInThreads) ? "✅" : "❌"} Send Messages In Threads\n`;
           description += `${logsPerms.has(PermissionsBitField.Flags.ManageThreads) ? "✅" : "❌"} Manage Threads\n`;
+        } else {
+          description += `❌ Channel not found or deleted\n`;
         }
       }
 
@@ -154,14 +163,17 @@ module.exports = {
         const welcomeChannel = interaction.guild.channels.cache.get(
           app.verificationwelcomechannel,
         );
+        description += `\n**Verification Welcome Channel (${welcomeChannel ? welcomeChannel : 'Unknown/Deleted'})**\n`;
         if (welcomeChannel) {
-        const welcomePerms = welcomeChannel.permissionsFor(client.user);
-        description += `\n**Verification Welcome Channel (${welcomeChannel})**\n`;
-        description += `${welcomePerms.has(PermissionsBitField.Flags.ViewChannel) ? "✅" : "❌"} View Channel\n`;
-        description += `${welcomePerms.has(PermissionsBitField.Flags.SendMessages) ? "✅" : "❌"} Send Messages\n`;
-        description += `${welcomePerms.has(PermissionsBitField.Flags.ReadMessageHistory) ? "✅" : "❌"} Read Message History\n`;
+          const welcomePerms = welcomeChannel.permissionsFor(botMember);
+          description += `${welcomePerms.has(PermissionsBitField.Flags.ViewChannel) ? "✅" : "❌"} View Channel\n`;
+          description += `${welcomePerms.has(PermissionsBitField.Flags.SendMessages) ? "✅" : "❌"} Send Messages\n`;
+          description += `${welcomePerms.has(PermissionsBitField.Flags.ReadMessageHistory) ? "✅" : "❌"} Read Message History\n`;
+          description += `${welcomePerms.has(PermissionsBitField.Flags.EmbedLinks) ? "✅" : "❌"} Embed Links\n`;
+        } else {
+          description += `❌ Channel not found or deleted\n`;
+        }
       }
-    }
     }
 
     description += "\n### Role Hierarchy\n";
@@ -258,7 +270,7 @@ module.exports = {
 
     const embed = new EmbedBuilder()
       .setColor(hasIssues ? 0xff0000 : 0x00ff00)
-      .setTitle("🔍 Advanced Permission Analysis")
+      .setTitle("Permission Check Results")
       .setDescription(description)
       .setFooter({
         text: "✅ = Has Permission/Can Manage | ❌ = Missing Permission/Cannot Manage | ⚠️ = Additional Permission | ℹ️ = Info Only",

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -191,7 +191,8 @@ async function extractUserId(interaction) {
   if (interaction.message?.flags?.has(MessageFlags.IsComponentsV2)) {
     if (
       (interaction.customId.includes("question_") ||
-      interaction.customId.includes("questionModal_"))
+      interaction.customId.includes("questionModal_") ||
+      interaction.customId.includes("denyModal_"))
     ) {
       const userIdMatch = interaction.customId.match(/_(\d+)$/);
       if (userIdMatch?.[1] && userIdMatch?.[1].length >= 17) {


### PR DESCRIPTION
- Resets the time-out of an application each time an answer is submitted.
- Reverses the order of the finishmessage and container creation (prevents finish message from trying to send if they've been kicked or left)
- Adds a few extra checks to the checkpermissions command to reflect updated permission requirements (Mainly Embed Links)
- Attempts to fix "DiscordAPIError[40003]: You are opening direct messages too fast." by not using user.createDM() in shard0 and instead fetching the passed DM Channel ID from the original DM channel. Also when an error occurs use .followup() instead of user.send to prevent sending DMs to user.
- Fixes bug where if it falls back to the default application (called "verification")), it applies the proper ID to the application buttons.