### PR TITLE
General bugfixes

### DIFF
--- a/button_commands/customization/setImage.js
+++ b/button_commands/customization/setImage.js
@@ -59,6 +59,14 @@ module.exports = async ({ interaction, context }) => {
         return;
       }
 
+      if (!collectedimage.startsWith("http://") && !collectedimage.startsWith("https://")) {
+        await interaction.followUp({
+          content: "Please provide a valid image file or full image URL.",
+          flags: MessageFlags.Ephemeral,
+        });
+        return;
+      }
+
       const imageAsset = await fetchImage(collectedimage);
       const uploadedImage = await uploadCustomizationImage({
         serverId: interaction.guild.id,
@@ -149,9 +157,16 @@ async function fetchImage(url) {
   };
 
   const fetch = (await import("node-fetch")).default;
-  const response = await fetch(url, { size: 15 * 1024 * 1024 });
+  
+  let response;
+  try {
+    response = await fetch(url, { size: 15 * 1024 * 1024 });
+  } catch (err) {
+    throw new Error("Invalid image URL or failed to connect.");
+  }
+
   if (!response.ok) {
-    throw new Error("Failed to fetch image");
+    throw new Error("Failed to fetch image. Make sure the URL is public and valid.");
   }
 
   const contentType = response.headers.get("content-type");

--- a/button_commands/customization/setImage.js
+++ b/button_commands/customization/setImage.js
@@ -161,7 +161,7 @@ async function fetchImage(url) {
   let response;
   try {
     response = await fetch(url, { size: 15 * 1024 * 1024 });
-  } catch (err) {
+  } catch {
     throw new Error("Invalid image URL or failed to connect.");
   }
 

--- a/button_commands/setupbuttons/finishsetup.js
+++ b/button_commands/setupbuttons/finishsetup.js
@@ -54,11 +54,30 @@ module.exports = async ({ interaction, client, context }) => {
     });
   }
 
+  if (questions.length === 0) {
+    return interaction.reply({
+      content: "You need to add at least one question.",
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  const verifyChannelObj = interaction.guild.channels.cache.get(verifyChannel);
+  if (!verifyChannelObj) {
+    return interaction.reply({
+      content: "The user verification channel has been deleted. Please set up the user verification channel again.",
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  await interaction.deferUpdate();
+
   const verifychannelembed = tempApp.verifychannelembed || {};
   const startmessage = tempApp.startmessage || {};
   const finishmessage = tempApp.finishmessage || {};
   const verifymessage = tempApp.verifymessage || {};
   const verificationwelcomemessage = tempApp.verificationwelcomemessage || {};
+
+
 
   await finalizeCustomizationImage(
     tempApp,
@@ -97,13 +116,6 @@ module.exports = async ({ interaction, client, context }) => {
   cleanConfig(verifymessage);
   cleanConfig(verificationwelcomemessage);
 
-  if (questions.length === 0) {
-    return interaction.reply({
-      content: "You need to add at least one question.",
-      flags: MessageFlags.Ephemeral,
-    });
-  }
-
   const imageCategories = [
     "verifychannelembed",
     "startmessage",
@@ -128,7 +140,7 @@ module.exports = async ({ interaction, client, context }) => {
     'questions', 'reviewchannel', 'verifylogs', 'verifychannel', 'verifiedrole',
     'verifychannelembed', 'startmessage', 'finishmessage', 'verifymessage',
     'verificationwelcomemessage', 'questionpingrole', 'unverifiedrole', 'pingrole',
-    'managerrole', 'verificationwelcomechannel', 'usethreads'
+    'managerrole', 'verificationwelcomechannel', 'usethreads', 'verifymessage_id'
   ];
 
   for (const field of fields) {
@@ -173,21 +185,13 @@ module.exports = async ({ interaction, client, context }) => {
     }
   }
 
-  const verifyChannelObj = interaction.guild.channels.cache.get(verifyChannel);
-  if (!verifyChannelObj) {
-    return interaction.reply({
-      content: "The user verification channel has been deleted. Please set up the user verification channel again.",
-      flags: MessageFlags.Ephemeral,
-    });
-  }
-
   const embedColor = isValidHexColor(finalApp?.verifychannelembed?.color) ? finalApp.verifychannelembed.color : (tempApp?.verifychannelembed?.color ?? "#3f7ff1");
-  const embedTitle = finalApp?.verifychannelembed?.title ?? tempApp?.verifychannelembed?.title ?? "Verification";
+  const embedTitle = finalApp?.verifychannelembed?.title ?? tempApp?.verifychannelembed?.title ?? null;
   const embedDescription = finalApp?.verifychannelembed?.description ?? tempApp?.verifychannelembed?.description ?? "Please verify yourself by clicking the button below.";
   const embedImage = finalApp?.verifychannelembed?.image ?? tempApp?.verifychannelembed?.image;
   const embedImageAsset = resolveImage(embedImage);
 
-  await updateVerifyMessage({
+  const result = await updateVerifyMessage({
     verifyChannelObj,
     botId: client.user.id,
     embedConfig: {
@@ -197,11 +201,17 @@ module.exports = async ({ interaction, client, context }) => {
       imageUrl: embedImageAsset.embedUrl,
       footer: tempApp.name,
     },
+    messageId: finalApp.verifymessage_id,
     button: {
       customId: `verifybutton_${finalApp.id}`,
       label: "Apply",
     },
   });
+
+  if (result?.message?.id && result.message.id !== finalApp.verifymessage_id) {
+    finalApp.verifymessage_id = result.message.id;
+    await finalApp.save().catch(e => console.error("Error saving verify message ID", e));
+  }
 
   await deleteTempApplication(interaction.guild.id, { id: tempApplicationId });
 
@@ -219,7 +229,7 @@ module.exports = async ({ interaction, client, context }) => {
     );
   }
 
-  await interaction.update({
+  await interaction.editReply({
     embeds: [finishembed],
     components: [],
     files: [],

--- a/button_commands/verifybutton.js
+++ b/button_commands/verifybutton.js
@@ -95,14 +95,14 @@ module.exports = async ({ interaction, client, applicationId }) => {
     // Find the application by ID and validate guild ownership
     const { application, error } = await getApplicationByIdWithFallback(applicationId, guildId);
 
-    applicationId = application.id;
-    
     if (error || !application) {
       return await interaction.editReply({
-        content: `This verification button is not configured correctly. Please contact the server staff. (${error || "Application not found"})`,
+        content: `This verification button or server setup is not configured correctly. Please contact the server staff. (${error || "Application not found"})`,
         flags: MessageFlags.Ephemeral,
       });
     }
+
+    applicationId = application.id;
 
     const appName = application.name;
     const {
@@ -1095,7 +1095,7 @@ async function processVerificationResult(
 
     user = user || interaction.user;
 
-    const { container, attachment } = await constructApplicationEmbed(
+    const containerResult = await constructApplicationEmbed(
       user,
       botQuestions,
       responses,
@@ -1105,11 +1105,13 @@ async function processVerificationResult(
       appName,
     );
 
-    if(!container) {
+    if(!containerResult || !containerResult.container) {
       //try to send image to user:
       dmChannel.send({ content: "An error occurred while processing your verification. This can happen when you left or have been kicked from the server during your application."  }).catch(() => {});
       return;
     }
+
+    const { container, attachment } = containerResult;
 
     //create the buttons
     const verify = new ActionRowBuilder().addComponents(

--- a/js/customizationImages.js
+++ b/js/customizationImages.js
@@ -194,8 +194,14 @@ async function promoteCustomizationImage(image) {
     CacheControl: "public, max-age=31536000, immutable",
   });
 
-  await r2Client.send(copyCommand);
-  await deleteImage(image);
+  try {
+    await r2Client.send(copyCommand);
+    await deleteImage(image);
+  } catch (error) {
+    if (error.name !== "NoSuchKey" && error.Code !== "NoSuchKey") {
+      console.error(`Failed to promote image ${image.key}:`, error);
+    }
+  }
 
   return serializeImage({
     ...image,

--- a/js/verifyChannelUtils.js
+++ b/js/verifyChannelUtils.js
@@ -15,7 +15,7 @@ async function findVerifyMessage(verifyChannelObj, botId, embedConfig) {
   const verificationMessages = await verifyChannelObj.messages.fetch({
     limit: 50,
   });
-  return verificationMessages.find(
+  return verificationMessages?.find?.(
     (m) =>
       m.author.id === botId &&
       m.embeds.length > 0 &&
@@ -47,13 +47,30 @@ async function updateVerifyMessage(opts) {
     botId,
     embedConfig,
     button,
+    messageId,
   } = opts;
 
-  const verificationMessage = await findVerifyMessage(
-    verifyChannelObj,
-    botId,
-    embedConfig,
-  );
+  let verificationMessage = null;
+
+  if (messageId) {
+    try {
+      verificationMessage = await verifyChannelObj.messages.fetch(messageId);
+    } catch {
+      verificationMessage = null;
+    }
+    
+    if (verificationMessage && verificationMessage.author.id !== botId) {
+      verificationMessage = null;
+    }
+  }
+
+  if (!verificationMessage) {
+    verificationMessage = await findVerifyMessage(
+      verifyChannelObj,
+      botId,
+      embedConfig,
+    );
+  }
 
   const embed = new EmbedBuilder()
     .setColor(isValidHexColor(embedConfig.color) ? embedConfig.color : DEFAULT_EMBED_COLOR)
@@ -75,7 +92,7 @@ async function updateVerifyMessage(opts) {
       embeds: [embed],
       components: [row],
     });
-
+    
     return {
       action: "created",
       message: newMessage,

--- a/models/Application.js
+++ b/models/Application.js
@@ -41,6 +41,9 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.JSONB,
       defaultValue: [],
     },
+    verifymessage_id: {
+      type: DataTypes.STRING,
+    },
     pingrole: {
       type: DataTypes.JSONB,
       defaultValue: [],

--- a/models/TempApplication.js
+++ b/models/TempApplication.js
@@ -49,6 +49,9 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.JSONB,
       defaultValue: [],
     },
+    verifymessage_id: { 
+      type: DataTypes.STRING,
+    },
     pingrole: {
       type: DataTypes.JSONB,
       defaultValue: [],


### PR DESCRIPTION
- Better checks in setImage.js to catch cases where a link isn't a valid URL.
- Reorganised checks in finishsetup.js to check if user has questions setup and verifychannel is valid *before* doing database saves.
- Sending the verify channel embed now also returns the message ID to be saved in the serverconfig for less ratelimiting when editing.
- Adds bugfix in verifybutton.js to prevent containercreation from crashing when user leaves.
- Adds error catching when saving image for example when an image has been deleted or when an accidental double button press occurs.
- verifyChannelUtils.js has been adapted to using the verifymessage_id from configuration with channel fetch as a fallback.
- Application.js and TempApplication.js have been updated to include the verifymessage_id column
- When leaving the title empty during customisation it now properly saves the title as null instead of a default value.