### PR TITLE
Fix truncation bug at questioninfo.js

### DIFF
--- a/button_commands/setupbuttons/questioninfo.js
+++ b/button_commands/setupbuttons/questioninfo.js
@@ -86,15 +86,16 @@ module.exports = async ({ interaction, context, applicationId, tempApplicationId
       .setMaxValues(1);
 
     questions.forEach((question, index) => {
+      const desc = question.mcq?.length > 0
+        ? question.mcq.map((option) => option.label ?? option).join("; ")
+        : "No multiple choice options";
+
       selectMenu.addOptions({
         label:
           question.content.length > 100
             ? question.content.slice(0, 97) + "..."
             : question.content,
-        description:
-          question.mcq?.length > 0
-            ? question.mcq.map((option) => (option.label ?? option) > 100 ? (option.label ?? option).slice(0, 97) + "..." : (option.label ?? option)).join("; ")
-            : "No multiple choice options",
+        description: desc.length > 100 ? desc.slice(0, 97) + "..." : desc,
         value: `${index + 1}`,
       });
     });

--- a/js/firsttimequestions.js
+++ b/js/firsttimequestions.js
@@ -88,15 +88,16 @@ async function firsttimequestions({ interaction, applicationId, tempApplicationI
       .setMaxValues(1);
 
     questions.forEach((question, index) => {
+      const desc = question.mcq?.length > 0
+        ? question.mcq.map((option) => option.label ?? option).join("; ")
+        : "No multiple choice options";
+
       selectMenu.addOptions({
         label:
           question.content.length > 100
             ? question.content.slice(0, 97) + "..."
             : question.content,
-        description:
-          question.mcq?.length > 0
-            ? question.mcq.map((option) => (option.label ?? option) > 100 ? (option.label ?? option).slice(0, 97) + "..." : (option.label ?? option)).join("; ")
-            : "No multiple choice options",
+        description: desc.length > 100 ? desc.slice(0, 97) + "..." : desc,
         value: `${index + 1}`,
       });
     });

--- a/menu_commands/questionSelectMenu.js
+++ b/menu_commands/questionSelectMenu.js
@@ -43,17 +43,20 @@ module.exports = async ({ interaction, client, context }) => {
     .setStyle(TextInputStyle.Paragraph)
     .setPlaceholder("Enter your question here")
     .setValue(question.content)
-    .setMaxLength(512)
+    .setMaxLength(1024)
     .setRequired(false);
 
+  const desc = question.mcq?.length > 0 
+    ? question.mcq.map((option) => option.label ?? option).join("\n") 
+    : "";
 
   const MCQ = new TextInputBuilder()
     .setCustomId("mcq")
-    .setLabel("Multiple Choice Question, 1 option/line max 9")
+    .setLabel("Multiple Choice Question, 1 option/line max 20 options (leave empty for regular question)")
     .setStyle(TextInputStyle.Paragraph)
     .setPlaceholder("List of options. Every option should be on a new line")
-    .setValue(question.mcq?.length > 0 ? question.mcq.map((option) => option.label ?? option).join("\n") : "")
-    .setMaxLength(512)
+    .setValue(desc.slice(0, 2048))
+    .setMaxLength(2048)
     .setRequired(false);
 
   const questionRow = new ActionRowBuilder().addComponents(Question);

--- a/modal_commands/addQuestionModal.js
+++ b/modal_commands/addQuestionModal.js
@@ -21,8 +21,9 @@ module.exports = async ({ interaction, client, context }) => {
   const mcq = interaction.fields.getTextInputValue(`mcq`);
   let mcqArray = mcq ? mcq.split("\n") : [];
 
-  if (mcqArray.length > 9) {
-    mcqArray = mcqArray.slice(0, 9);
+  //allow max of 20 MCQ options
+  if (mcqArray.length > 20) {
+    mcqArray = mcqArray.slice(0, 20);
   }
 
   const { tempApp: temporarySetup, error } = await getTempApplicationById(tempApplicationId, interaction.guild.id);


### PR DESCRIPTION
mcq options were being truncated within the map causing the total description to still be able to be longer than 100 characters. I have seperated the description creation logic and check the length over the entire desc object instead.