### PR TITLE
Fixes status being "deny" instead of "denied"

### DIFF
--- a/js/applicationHandler.js
+++ b/js/applicationHandler.js
@@ -755,7 +755,7 @@ async function processVerificationResult(
         user_id: user.id,
         guild_id: guildId,
         app_id: String(applicationId),
-        status: reason,
+        status: reason === "deny" ? "denied" : reason === "kick" ? "kicked" : reason,
         data: encryptData(finalPayload, encryptionKey),
       });
 


### PR DESCRIPTION
Fixes status being "deny" instead of "denied", this caused any autodenies to not count to the denial threshold.
This really is a patch and I should just refactor most of this logic in the future...