### PR TITLE
Update .env.example & errorstack slice

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,8 @@ ENCRYPTION_KEY=your_encryption_key_here # 64 characters in hex: Must be 32 bytes
 # Misc configuration
 POST_STATS=false
 BUG_REPORT_MODE=user # This can be none, chan for a output to a channel, user for output to a DM or both if you want to use channel and DM.
-DM_BUG_USER=developer_id_here # This is the user the bot will DM if in user or both mode.
-DM_BUG_CHAN= # Channel for sending errors to, if in chan or both mode.
+BUG_REPORT_USER=developer_id_here # This is the user the bot will DM if in user or both mode.
+BUG_REPORT_CHAN= # Channel for sending errors to, if in chan or both mode.
 
 # Image server(For debugging you can define these as blank, but they are required).
 S3ACCOUNT_ID= 

--- a/js/ErrorHandling.js
+++ b/js/ErrorHandling.js
@@ -195,7 +195,7 @@ class ErrorHandler {
 
 		let Stack_out = "";
 		Stack_out += "```";
-		Stack_out += error.stack?.slice(0, 1024);
+		Stack_out += error.stack?.slice(0, 1018); //account for ``` adding to character limit 1024-6=1018
 		Stack_out += "```";
 
 		const devEmbed = new EmbedBuilder()


### PR DESCRIPTION
- Update .env.example to use BUG_REPORT prefix instead of DM_BUG.
- Accounted for length of ``` prefix and suffix when sending error stack at bug report to make sure total Stack_out doesn't exceed 1024 characters.